### PR TITLE
Fix: Enhance Docker Configuration for GUI Support

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,14 +1,3 @@
-x-default-robot-lab-environment: &default-robot-lab-environment
-  - OMNI_KIT_ALLOW_ROOT=1
-
-x-default-robot-lab-deploy: &default-robot-lab-deploy
-  resources:
-    reservations:
-      devices:
-        - driver: nvidia
-          count: all
-          capabilities: [ gpu ]
-
 services:
   robot-lab:
     env_file: .env.base
@@ -21,13 +10,21 @@ services:
     image: robot-lab
     container_name: robot-lab
     volumes:
-      - type: bind
-        source: ../
-        target: ${DOCKER_ISAACLAB_EXTENSION_TEMPLATE_PATH}
+      - ../:${DOCKER_ISAACLAB_EXTENSION_TEMPLATE_PATH}
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - $XAUTHORITY:/root/.Xauthority
     network_mode: host
-    environment: *default-robot-lab-environment
-    deploy: *default-robot-lab-deploy
-    # This is the entrypoint for the container
+    environment:
+      OMNI_KIT_ALLOW_ROOT: 1
+      DISPLAY: $DISPLAY
+      XAUTHORITY: /root/.Xauthority
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
     entrypoint: bash
     stdin_open: true
     tty: true

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,3 +1,16 @@
+x-default-robot-lab-environment: &default-robot-lab-environment
+  OMNI_KIT_ALLOW_ROOT: 1
+  DISPLAY: $DISPLAY
+  XAUTHORITY: /root/.Xauthority
+
+x-default-robot-lab-deploy: &default-robot-lab-deploy
+  resources:
+    reservations:
+      devices:
+        - driver: nvidia
+          count: all
+          capabilities: [gpu]
+
 services:
   robot-lab:
     env_file: .env.base
@@ -5,26 +18,21 @@ services:
       context: ../
       dockerfile: docker/Dockerfile
       args:
-        - ISAACLAB_BASE_IMAGE_ARG=${ISAACLAB_BASE_IMAGE}
-        - DOCKER_ISAACLAB_EXTENSION_TEMPLATE_PATH_ARG=${DOCKER_ISAACLAB_EXTENSION_TEMPLATE_PATH}
+        ISAACLAB_BASE_IMAGE_ARG: ${ISAACLAB_BASE_IMAGE}
+        DOCKER_ISAACLAB_EXTENSION_TEMPLATE_PATH_ARG: ${DOCKER_ISAACLAB_EXTENSION_TEMPLATE_PATH}
     image: robot-lab
     container_name: robot-lab
     volumes:
-      - ../:${DOCKER_ISAACLAB_EXTENSION_TEMPLATE_PATH}
+      - type: bind
+        source: ../
+        target: ${DOCKER_ISAACLAB_EXTENSION_TEMPLATE_PATH}
       - /tmp/.X11-unix:/tmp/.X11-unix
       - $XAUTHORITY:/root/.Xauthority
     network_mode: host
     environment:
-      OMNI_KIT_ALLOW_ROOT: 1
-      DISPLAY: $DISPLAY
-      XAUTHORITY: /root/.Xauthority
+      <<: *default-robot-lab-environment
     deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
+      <<: *default-robot-lab-deploy
     entrypoint: bash
     stdin_open: true
     tty: true

--- a/scripts/rsl_rl/base/play.py
+++ b/scripts/rsl_rl/base/play.py
@@ -155,14 +155,21 @@ def main():
 
     # export policy to onnx/jit
     export_model_dir = os.path.join(os.path.dirname(resume_path), "exported")
+    
+    # Check if actor_critic is available in ppo_runner.alg
+    if hasattr(ppo_runner.alg, "actor_critic"):
+        policy_model = ppo_runner.alg.actor_critic
+    else:
+        policy_model = ppo_runner.alg.policy
+    
     export_policy_as_onnx(
-        actor_critic=ppo_runner.alg.actor_critic,
+        actor_critic=policy_model,
         normalizer=ppo_runner.obs_normalizer,
         path=export_model_dir,
         filename="policy.onnx",
     )
     export_policy_as_jit(
-        actor_critic=ppo_runner.alg.actor_critic,
+        actor_critic=policy_model,
         normalizer=ppo_runner.obs_normalizer,
         path=export_model_dir,
         filename="policy.pt",

--- a/scripts/rsl_rl/base/play.py
+++ b/scripts/rsl_rl/base/play.py
@@ -143,7 +143,7 @@ def main():
         env = gym.wrappers.RecordVideo(env, **video_kwargs)
 
     # wrap around environment for rsl-rl
-    env = RslRlVecEnvWrapper(env)
+    env = RslRlVecEnvWrapper(env, clip_actions=agent_cfg.clip_actions)
 
     print(f"[INFO]: Loading model checkpoint from: {resume_path}")
     # load previously trained model
@@ -156,13 +156,13 @@ def main():
     # export policy to onnx/jit
     export_model_dir = os.path.join(os.path.dirname(resume_path), "exported")
     export_policy_as_onnx(
-        actor_critic=ppo_runner.alg.actor_critic,
+        actor_critic=ppo_runner.alg.policy,
         normalizer=ppo_runner.obs_normalizer,
         path=export_model_dir,
         filename="policy.onnx",
     )
     export_policy_as_jit(
-        actor_critic=ppo_runner.alg.actor_critic,
+        actor_critic=ppo_runner.alg.policy,
         normalizer=ppo_runner.obs_normalizer,
         path=export_model_dir,
         filename="policy.pt",


### PR DESCRIPTION
This PR resolves [[Issue #35](https://github.com/fan-ziqi/robot_lab/issues/35)](https://github.com/fan-ziqi/robot_lab/issues/35) by fixing two key problems:

### 🐛 Bug Fixes

1. **Docker Compose GUI Support**
   - Added `DISPLAY` and `XAUTHORITY` environment variables.
   - Mounted `/tmp/.X11-unix` and `$XAUTHORITY` to enable GUI rendering inside the container (e.g., for IsaacLab visualization).
   - Ensured compatibility with X11 forwarding, especially when using remote desktop tools.

2. **Policy Export Crash in `play.py`**
   - Fixed a logic bug where `ppo_runner.alg.actor_critic` was used directly, even when not present.
   - Replaced with a conditional assignment to `policy_model` (fallback to `alg.policy`), ensuring compatibility with different PPO implementations.
   - Updated both ONNX and JIT export to use `policy_model`.

### ✅ Summary of Changes

- `docker/docker-compose.yaml`: Enhanced for GUI-based usage with X11.
- `scripts/rsl_rl/base/play.py`: Made policy export more robust and backward-compatible.

---

Let me know if you'd like me to break this into two separate PRs (Docker + Script), or squash into a single commit.