### PR TITLE
Update velocity_env_cfg.py

### DIFF
--- a/source/robot_lab/robot_lab/tasks/locomotion/velocity/velocity_env_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/locomotion/velocity/velocity_env_cfg.py
@@ -71,7 +71,7 @@ class MySceneCfg(InteractiveSceneCfg):
     height_scanner = RayCasterCfg(
         prim_path="{ENV_REGEX_NS}/Robot/base",
         offset=RayCasterCfg.OffsetCfg(pos=(0.0, 0.0, 20.0)),
-        attach_yaw_only=True,
+        ray_alignment='yaw',
         pattern_cfg=patterns.GridPatternCfg(resolution=0.1, size=[1.6, 1.0]),
         debug_vis=False,
         mesh_prim_paths=["/World/ground"],
@@ -79,7 +79,7 @@ class MySceneCfg(InteractiveSceneCfg):
     height_scanner_base = RayCasterCfg(
         prim_path="{ENV_REGEX_NS}/Robot/base",
         offset=RayCasterCfg.OffsetCfg(pos=(0.0, 0.0, 20.0)),
-        attach_yaw_only=True,
+        ray_alignment='yaw',
         pattern_cfg=patterns.GridPatternCfg(resolution=0.05, size=(0.1, 0.1)),
         debug_vis=False,
         mesh_prim_paths=["/World/ground"],


### PR DESCRIPTION
My Isaac Lab version is 2.1. When i try the demo:
`python scripts/rsl_rl/base/train.py --task RobotLab-Isaac-Velocity-Rough-Unitree-A1-v0 --headless`
It keeps giving me warning prompts and forcing me to refresh the screen. Although this doesn't affect my usage, it looks uncomfortable.
`2025-07-11 10:36:19 [13,631ms] [Warning] [isaaclab.sensors.ray_caster.ray_caster] The attach_yaw_only property will be deprecated in a future release. Please use ray_alignment='yaw' instead.`
![c58f54167b7cce5eb67fa5ae5899359](https://github.com/user-attachments/assets/14398f50-daba-43c7-9b32-d1412eac7165)
