### PR TITLE
feat(cusrl): support hydra for configuration overwriting

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ python scripts/reinforcement_learning/rsl_rl/train.py --task=<ENV_NAME> --headle
 python scripts/reinforcement_learning/rsl_rl/play.py --task=<ENV_NAME>
 ```
 
-CusRL (**Experimental**:​​ Hydra not supported yet):
+CusRL (**Experimental**):
 
 ```bash
 # Train

--- a/scripts/reinforcement_learning/cusrl/train.py
+++ b/scripts/reinforcement_learning/cusrl/train.py
@@ -51,6 +51,7 @@ import torch
 from datetime import datetime
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.envs import DirectMARLEnvCfg  # noqa: F401
 from isaaclab.envs import DirectRLEnvCfg  # noqa: F401
@@ -58,7 +59,6 @@ from isaaclab.envs import ManagerBasedRLEnvCfg  # noqa: F401
 from isaaclab.envs import DirectMARLEnv, multi_agent_to_single_agent
 from isaaclab.utils.dict import print_dict
 from isaaclab_tasks.utils.hydra import hydra_task_config  # noqa: F401
-from isaaclab_tasks.utils.parse_cfg import load_cfg_from_registry
 
 import robot_lab.tasks  # noqa: F401
 
@@ -68,14 +68,9 @@ torch.backends.cudnn.deterministic = False
 torch.backends.cudnn.benchmark = False
 
 
-# @hydra_task_config(args_cli.task, "cusrl_cfg_entry_point")
-# def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg):
-def main():
+@hydra_task_config(args_cli.task, "cusrl_cfg_entry_point")
+def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agent_cfg: TrainerCfg):
     """Train with CusRL agent."""
-    # override configurations with non-hydra CLI arguments
-    env_cfg = load_cfg_from_registry(args_cli.task, "env_cfg_entry_point")
-    agent_cfg = load_cfg_from_registry(args_cli.task, "cusrl_cfg_entry_point")
-
     env_cfg.scene.num_envs = args_cli.num_envs if args_cli.num_envs is not None else env_cfg.scene.num_envs
     agent_cfg.max_iterations = (
         args_cli.max_iterations if args_cli.max_iterations is not None else agent_cfg.max_iterations

--- a/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/humanoid/booster_t1/agents/cusrl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/humanoid/booster_t1/agents/cusrl_ppo_cfg.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.utils import configclass
 
 
 @configclass
-class BoosterT1RoughTrainerCfg:
+class BoosterT1RoughTrainerCfg(TrainerCfg):
     max_iterations = 3000
     save_interval = 100
     experiment_name = "booster_t1_rough"

--- a/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/humanoid/fftai_gr1t1/agents/cusrl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/humanoid/fftai_gr1t1/agents/cusrl_ppo_cfg.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.utils import configclass
 
 
 @configclass
-class FTAIGR1T1RoughTrainerCfg:
+class FTAIGR1T1RoughTrainerCfg(TrainerCfg):
     max_iterations = 3000
     save_interval = 100
     experiment_name = "fftai_gr1t1_rough"

--- a/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/humanoid/fftai_gr1t2/agents/cusrl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/humanoid/fftai_gr1t2/agents/cusrl_ppo_cfg.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.utils import configclass
 
 
 @configclass
-class FTAIGR1T2RoughTrainerCfg:
+class FTAIGR1T2RoughTrainerCfg(TrainerCfg):
     max_iterations = 3000
     save_interval = 100
     experiment_name = "fftai_gr1t2_rough"

--- a/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/humanoid/magiclab_magicbot_gen1/agents/cusrl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/humanoid/magiclab_magicbot_gen1/agents/cusrl_ppo_cfg.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.utils import configclass
 
 
 @configclass
-class MagicLabBotGen1RoughTrainerCfg:
+class MagicLabBotGen1RoughTrainerCfg(TrainerCfg):
     max_iterations = 3000
     save_interval = 100
     experiment_name = "magiclab_bot_gen1_rough"

--- a/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/humanoid/magiclab_magicbot_z1/agents/cusrl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/humanoid/magiclab_magicbot_z1/agents/cusrl_ppo_cfg.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.utils import configclass
 
 
 @configclass
-class MagicLabBotZ1RoughTrainerCfg:
+class MagicLabBotZ1RoughTrainerCfg(TrainerCfg):
     max_iterations = 3000
     save_interval = 100
     experiment_name = "magiclab_bot_z1_rough"

--- a/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/humanoid/openloong_loong/agents/cusrl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/humanoid/openloong_loong/agents/cusrl_ppo_cfg.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.utils import configclass
 
 
 @configclass
-class OpenloongLoongRoughTrainerCfg:
+class OpenloongLoongRoughTrainerCfg(TrainerCfg):
     max_iterations = 5000
     save_interval = 100
     experiment_name = "openloong_loong_rough"

--- a/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/humanoid/roboparty_atom01/agents/cusrl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/humanoid/roboparty_atom01/agents/cusrl_ppo_cfg.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.utils import configclass
 
 
 @configclass
-class RoboPartyATOM01RoughTrainerCfg:
+class RoboPartyATOM01RoughTrainerCfg(TrainerCfg):
     max_iterations = 3000
     save_interval = 100
     experiment_name = "roboparty_atom01_rough"

--- a/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/humanoid/robotera_xbot/agents/cusrl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/humanoid/robotera_xbot/agents/cusrl_ppo_cfg.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.utils import configclass
 
 
 @configclass
-class RobotEraXbotRoughTrainerCfg:
+class RobotEraXbotRoughTrainerCfg(TrainerCfg):
     max_iterations = 3000
     save_interval = 100
     experiment_name = "robotera_xbot_rough"

--- a/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/humanoid/unitree_g1/agents/cusrl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/humanoid/unitree_g1/agents/cusrl_ppo_cfg.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.utils import configclass
 
 
 @configclass
-class UnitreeG1RoughTrainerCfg:
+class UnitreeG1RoughTrainerCfg(TrainerCfg):
     max_iterations = 3000
     save_interval = 100
     experiment_name = "unitree_g1_rough"

--- a/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/humanoid/unitree_h1/agents/cusrl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/humanoid/unitree_h1/agents/cusrl_ppo_cfg.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.utils import configclass
 
 
 @configclass
-class UnitreeH1RoughTrainerCfg:
+class UnitreeH1RoughTrainerCfg(TrainerCfg):
     max_iterations = 3000
     save_interval = 100
     experiment_name = "unitree_h1_rough"

--- a/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/others/unitree_a1_handstand/agents/cusrl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/others/unitree_a1_handstand/agents/cusrl_ppo_cfg.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.utils import configclass
 
 
 @configclass
-class UnitreeA1HandStandRoughTrainerCfg:
+class UnitreeA1HandStandRoughTrainerCfg(TrainerCfg):
     max_iterations = 5000
     save_interval = 100
     experiment_name = "unitree_a1_handstand_rough"

--- a/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/quadruped/anymal_d/agents/cusrl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/quadruped/anymal_d/agents/cusrl_ppo_cfg.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.utils import configclass
 
 
 @configclass
-class AnymalDRoughTrainerCfg:
+class AnymalDRoughTrainerCfg(TrainerCfg):
     max_iterations = 3000
     save_interval = 100
     experiment_name = "anymal_d_rough"

--- a/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/quadruped/deeprobotics_lite3/agents/cusrl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/quadruped/deeprobotics_lite3/agents/cusrl_ppo_cfg.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.utils import configclass
 
 
 @configclass
-class DeeproboticsLite3RoughTrainerCfg:
+class DeeproboticsLite3RoughTrainerCfg(TrainerCfg):
     max_iterations = 20000
     save_interval = 100
     experiment_name = "deeprobotics_lite3_rough"

--- a/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/quadruped/magiclab_magicdog/agents/cusrl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/quadruped/magiclab_magicdog/agents/cusrl_ppo_cfg.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.utils import configclass
 
 
 @configclass
-class MagicDogRoughTrainerCfg:
+class MagicDogRoughTrainerCfg(TrainerCfg):
     max_iterations = 20000
     save_interval = 100
     experiment_name = "magicdog_rough"

--- a/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/quadruped/unitree_a1/agents/cusrl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/quadruped/unitree_a1/agents/cusrl_ppo_cfg.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.utils import configclass
 
 
 @configclass
-class UnitreeA1RoughTrainerCfg:
+class UnitreeA1RoughTrainerCfg(TrainerCfg):
     max_iterations = 20000
     save_interval = 100
     experiment_name = "unitree_a1_rough"

--- a/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/quadruped/unitree_b2/agents/cusrl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/quadruped/unitree_b2/agents/cusrl_ppo_cfg.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.utils import configclass
 
 
 @configclass
-class UnitreeB2RoughTrainerCfg:
+class UnitreeB2RoughTrainerCfg(TrainerCfg):
     max_iterations = 20000
     save_interval = 100
     experiment_name = "unitree_b2_rough"

--- a/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/quadruped/unitree_go2/agents/cusrl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/quadruped/unitree_go2/agents/cusrl_ppo_cfg.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.utils import configclass
 
 
 @configclass
-class UnitreeGo2RoughTrainerCfg:
+class UnitreeGo2RoughTrainerCfg(TrainerCfg):
     max_iterations = 20000
     save_interval = 100
     experiment_name = "unitree_go2_rough"

--- a/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/wheeled/ddtrobot_tita/agents/cusrl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/wheeled/ddtrobot_tita/agents/cusrl_ppo_cfg.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.utils import configclass
 
 
 @configclass
-class DDTRobotTitaRoughTrainerCfg:
+class DDTRobotTitaRoughTrainerCfg(TrainerCfg):
     max_iterations = 20000
     save_interval = 100
     experiment_name = "ddtrobot_tita_rough"

--- a/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/wheeled/deeprobotics_m20/agents/cusrl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/wheeled/deeprobotics_m20/agents/cusrl_ppo_cfg.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.utils import configclass
 
 
 @configclass
-class DeeproboticsM20RoughTrainerCfg:
+class DeeproboticsM20RoughTrainerCfg(TrainerCfg):
     max_iterations = 20000
     save_interval = 100
     experiment_name = "deeprobotics_m20_rough"

--- a/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/wheeled/magiclab_magicdogw/agents/cusrl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/wheeled/magiclab_magicdogw/agents/cusrl_ppo_cfg.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.utils import configclass
 
 
 @configclass
-class MagicDogWRoughTrainerCfg:
+class MagicDogWRoughTrainerCfg(TrainerCfg):
     max_iterations = 20000
     save_interval = 100
     experiment_name = "magicdog_w_rough"

--- a/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/wheeled/unitree_b2w/agents/cusrl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/wheeled/unitree_b2w/agents/cusrl_ppo_cfg.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.utils import configclass
 
 
 @configclass
-class UnitreeB2WRoughTrainerCfg:
+class UnitreeB2WRoughTrainerCfg(TrainerCfg):
     max_iterations = 20000
     save_interval = 100
     experiment_name = "unitree_b2w_rough"

--- a/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/wheeled/unitree_go2w/agents/cusrl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/wheeled/unitree_go2w/agents/cusrl_ppo_cfg.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.utils import configclass
 
 
 @configclass
-class UnitreeGo2WRoughTrainerCfg:
+class UnitreeGo2WRoughTrainerCfg(TrainerCfg):
     max_iterations = 20000
     save_interval = 100
     experiment_name = "unitree_go2w_rough"

--- a/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/wheeled/zsibot_zsl1w/agents/cusrl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/locomotion/velocity/config/wheeled/zsibot_zsl1w/agents/cusrl_ppo_cfg.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import cusrl
+from cusrl.environment.isaaclab import TrainerCfg
 
 from isaaclab.utils import configclass
 
 
 @configclass
-class ZsibotZSL1WRoughTrainerCfg:
+class ZsibotZSL1WRoughTrainerCfg(TrainerCfg):
     max_iterations = 20000
     save_interval = 100
     experiment_name = "zsibot_zsl1w_rough"

--- a/source/robot_lab/setup.py
+++ b/source/robot_lab/setup.py
@@ -24,7 +24,7 @@ INSTALL_REQUIRES = [
     "pandas",
     "pinocchio",
     # rl
-    "cusrl[all]==1.1.0",
+    "cusrl[all]==1.1.1",
 ]
 
 # Installation operation


### PR DESCRIPTION
This commit contains:
- upgrade cusrl to v1.1.1;
- make cusrl config classes to inherit `cusrl.environment.isaaclab.TrainerCfg` to use `to_dict` and `from_dict` implemented in `cusrl`;
- modify train.py accordingly