### PR TITLE
feat(pace): integrate PACE actuator system identification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ _build
 
 # LSP
 pyrightconfig.json
+
+# PACE recorded chirp data (root-level only; do not match source/robot_lab/data/Robots)
+/data/

--- a/README.md
+++ b/README.md
@@ -256,6 +256,37 @@ BeyondMimic for Unitree G1:
   python scripts/reinforcement_learning/rsl_rl/play.py --task=RobotLab-Isaac-BeyondMimic-Flat-Unitree-G1-v0 --num_envs 2
   ```
 
+PACE for actuator system identification:
+
+PACE (Precise Adaptation through Continuous Evolution) estimates physical actuator and joint parameters (armature, viscous friction, static/dynamic friction, encoder bias, command delay) from chirp-excitation data using CMA-ES, then lets you apply those parameters back into your simulation for higher-fidelity sim-to-real transfer. This integration ports the upstream [leggedrobotics/pace-sim2real](https://github.com/leggedrobotics/pace-sim2real) into `robot_lab` and registers a demo task `Isaac-Pace-Anymal-D-v0`. See the [PACE documentation](https://pace.filipbjelonic.com) for theoretical background and the [paper](https://arxiv.org/pdf/2509.06342).
+
+> [!NOTE]
+> PACE is developed against Isaac Sim 5.0+. On Isaac Sim 4.5 the joint viscous friction setter is silently ignored, which degrades identification quality.
+
+- Step 1: collect chirp excitation data (or place real-robot recordings at `data/<robot_name>/chirp_data.pt`)
+
+  ```bash
+  python scripts/pace/data_collection.py --headless --task=Isaac-Pace-Anymal-D-v0
+  ```
+
+  Output: `data/anymal_d_sim/chirp_data.pt` containing `{time, dof_pos, des_dof_pos}`.
+
+- Step 2: run the CMA-ES parameter fit
+
+  ```bash
+  python scripts/pace/fit.py --headless --task=Isaac-Pace-Anymal-D-v0 --num_envs=4096
+  ```
+
+  Output: `logs/pace/anymal_d_sim/<timestamp>/{config.pt, mean_xxx.pt, best_trajectory.pt}` plus a TensorBoard run.
+
+- Step 3: visualize the best trajectory and score curve
+
+  ```bash
+  python scripts/pace/plot_trajectory.py --plot_trajectory --plot_score --robot_name=anymal_d_sim
+  ```
+
+To set up PACE for a new robot, follow the upstream [PACE basics tutorial](https://pace.filipbjelonic.com/tutorials/basics): create a per-robot env_cfg under `source/robot_lab/robot_lab/tasks/manager_based/pace/config/<robot>/` and register a new `Isaac-Pace-<Robot>-v0` task. The actuator model `PaceDCMotor`/`PaceDCMotorCfg` lives at `robot_lab.actuators` and the optimizer `CMAESOptimizer` at `robot_lab.tasks.manager_based.pace.optim`.
+
 Others (**Experimental**)
 
 - Train AMP Dance for Unitree G1
@@ -468,3 +499,4 @@ The project uses some code from the following open-source code repositories:
 
 - [linden713/humanoid_amp](https://github.com/linden713/humanoid_amp)
 - [HybridRobotics/whole_body_tracking](https://github.com/HybridRobotics/whole_body_tracking)
+- [leggedrobotics/pace-sim2real](https://github.com/leggedrobotics/pace-sim2real)

--- a/scripts/pace/data_collection.py
+++ b/scripts/pace/data_collection.py
@@ -1,0 +1,176 @@
+# © 2025 ETH Zurich, Robotic Systems Lab
+# Author: Filip Bjelonic
+# Licensed under the Apache License 2.0
+
+"""Script to collect chirp excitation data for PACE system identification."""
+
+"""Launch Isaac Sim Simulator first."""
+
+import argparse
+
+from isaaclab.app import AppLauncher
+
+# add argparse arguments
+parser = argparse.ArgumentParser(description="Pace agent for Isaac Lab environments.")
+parser.add_argument("--num_envs", type=int, default=1, help="Number of environments to simulate.")
+parser.add_argument("--task", type=str, default="Isaac-Pace-Anymal-D-v0", help="Name of the task.")
+parser.add_argument("--min_frequency", type=float, default=0.1, help="Minimum frequency for the chirp signal in Hz.")
+parser.add_argument("--max_frequency", type=float, default=10.0, help="Maximum frequency for the chirp signal in Hz.")
+parser.add_argument("--duration", type=float, default=20.0, help="Duration of the chirp signal in seconds.")
+# append AppLauncher cli args
+AppLauncher.add_app_launcher_args(parser)
+# parse the arguments
+args_cli = parser.parse_args()
+
+# launch omniverse app
+app_launcher = AppLauncher(args_cli)
+simulation_app = app_launcher.app
+
+"""Rest everything follows."""
+
+import gymnasium as gym
+import torch
+
+import isaaclab_tasks  # noqa: F401
+from isaaclab_tasks.utils import parse_env_cfg
+from torch import pi
+
+import robot_lab.tasks  # noqa: F401
+from robot_lab.utils.paths import project_root
+
+
+def main():
+    # parse configuration
+    env_cfg = parse_env_cfg(
+        args_cli.task, device=args_cli.device, num_envs=args_cli.num_envs
+    )
+    # create environment
+    env = gym.make(args_cli.task, cfg=env_cfg)
+
+    # print info (this is vectorized environment)
+    print(f"[INFO]: Gym observation space: {env.observation_space}")
+    print(f"[INFO]: Gym action space: {env.action_space}")
+    # reset environment
+
+    articulation = env.unwrapped.scene["robot"]
+
+    joint_order = env_cfg.sim2real.joint_order
+    joint_ids = torch.tensor([articulation.joint_names.index(name) for name in joint_order], device=env.unwrapped.device)
+
+    armature = torch.tensor([0.1] * len(joint_ids), device=env.unwrapped.device).unsqueeze(0)
+    damping = torch.tensor([4.5] * len(joint_ids), device=env.unwrapped.device).unsqueeze(0)
+    friction = torch.tensor([0.05] * len(joint_ids), device=env.unwrapped.device).unsqueeze(0)  # coulomb friction
+    bias = torch.tensor([0.05] * 12, device=env.unwrapped.device).unsqueeze(0)
+    time_lag = torch.tensor([[5]], dtype=torch.int, device=env.unwrapped.device)
+    env.reset()
+
+    articulation.write_joint_armature_to_sim(armature, joint_ids=joint_ids, env_ids=torch.arange(len(armature)))
+    articulation.data.default_joint_armature[:, joint_ids] = armature
+    articulation.write_joint_viscous_friction_coefficient_to_sim(damping, joint_ids=joint_ids, env_ids=torch.arange(len(damping)))
+    articulation.data.default_joint_viscous_friction_coeff[:, joint_ids] = damping
+    # note: modeling coulomb friction if joint_friction = joint_dynamic_friction
+    articulation.write_joint_friction_coefficient_to_sim(friction, joint_ids=joint_ids, env_ids=torch.tensor([0]))
+    articulation.data.default_joint_friction_coeff[:, joint_ids] = friction
+    articulation.write_joint_dynamic_friction_coefficient_to_sim(friction, joint_ids=joint_ids, env_ids=torch.tensor([0]))
+    articulation.data.default_joint_dynamic_friction_coeff[:, joint_ids] = friction
+    drive_types = articulation.actuators.keys()
+    for drive_type in drive_types:
+        drive_indices = articulation.actuators[drive_type].joint_indices
+        if isinstance(drive_indices, slice):
+            all_idx = torch.arange(joint_ids.shape[0], device=joint_ids.device)
+            drive_indices = all_idx[drive_indices]
+        comparison_matrix = (joint_ids.unsqueeze(1) == drive_indices.unsqueeze(0))
+        drive_joint_idx = torch.argmax(comparison_matrix.int(), dim=0)
+        articulation.actuators[drive_type].update_time_lags(time_lag)
+        articulation.actuators[drive_type].update_encoder_bias(bias[:, drive_joint_idx])
+        articulation.actuators[drive_type].reset(torch.arange(env.unwrapped.num_envs))
+
+    data_dir = project_root() / "data" / env_cfg.sim2real.robot_name
+
+    # Create a chirp signal for each action dimension
+
+    duration = args_cli.duration  # seconds
+    sample_rate = 1 / env.unwrapped.sim.get_physics_dt()  # Hz
+    num_steps = int(duration * sample_rate)
+    t = torch.linspace(0, duration, steps=num_steps, device=env.unwrapped.device)
+    f0 = args_cli.min_frequency  # Hz
+    f1 = args_cli.max_frequency  # Hz
+
+    # Linear chirp: phase = 2*pi*(f0*t + (f1-f0)/(2*duration)*t^2)
+    phase = 2 * pi * (f0 * t + ((f1 - f0) / (2 * duration)) * t ** 2)
+    chirp_signal = torch.sin(phase)
+
+    trajectory = torch.zeros((num_steps, len(joint_ids)), device=env.unwrapped.device)
+    trajectory[:, :] = chirp_signal.unsqueeze(-1)
+    trajectory_directions = torch.tensor(
+        [1.0, 1.0, 1.0, -1.0, 1.0, 1.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0],
+        device=env.unwrapped.device
+    )
+    # APPEND_PLACEHOLDER
+    trajectory_bias = torch.tensor(
+        [0.0, 0.4, 0.8] * 4,
+        device=env.unwrapped.device
+    )
+    trajectory_scale = torch.tensor(
+        [0.25, 0.5, -2.0] * 4,
+        device=env.unwrapped.device
+    )
+    trajectory[:, joint_ids] = (trajectory[:, joint_ids] + trajectory_bias.unsqueeze(0)) * trajectory_directions.unsqueeze(0) * trajectory_scale.unsqueeze(0)
+
+    articulation.write_joint_position_to_sim(trajectory[0, :].unsqueeze(0) + bias[0, joint_ids])
+    articulation.write_joint_velocity_to_sim(torch.zeros((1, len(joint_ids)), device=env.unwrapped.device))
+
+    counter = 0
+    # simulate environment
+    dof_pos_buffer = torch.zeros(num_steps, len(joint_ids), device=env.unwrapped.device)
+    dof_target_pos_buffer = torch.zeros(num_steps, len(joint_ids), device=env.unwrapped.device)
+    time_data = t
+    while simulation_app.is_running():
+        # run everything in inference mode
+        with torch.inference_mode():
+            # compute actions
+            dof_pos_buffer[counter, :] = env.unwrapped.scene.articulations["robot"].data.joint_pos[0, joint_ids] - bias[0]
+            actions = torch.zeros(env.action_space.shape, device=env.unwrapped.device)
+            actions = trajectory[counter % num_steps, :].unsqueeze(0).repeat(env.unwrapped.num_envs, 1)
+            # apply actions
+            obs, _, _, _, _ = env.step(actions)
+            dof_target_pos_buffer[counter, :] = env.unwrapped.scene.articulations["robot"]._data.joint_pos_target[0, joint_ids]
+            counter += 1
+            if counter % 400 == 0:
+                print(f"[INFO]: Step {counter/sample_rate} seconds")
+            if counter >= num_steps:
+                break
+
+    # close the simulator
+    env.close()
+
+    from time import sleep
+    sleep(1)  # wait a bit for everything to settle
+
+    (data_dir).mkdir(parents=True, exist_ok=True)
+    torch.save({
+        "time": time_data.cpu(),
+        "dof_pos": dof_pos_buffer.cpu(),
+        "des_dof_pos": dof_target_pos_buffer.cpu(),
+    }, data_dir / "chirp_data.pt")
+
+    import matplotlib.pyplot as plt
+
+    for i in range(len(joint_ids)):
+        plt.figure()
+        plt.plot(t.cpu().numpy(), dof_pos_buffer[:, i].cpu().numpy(), label=f"{joint_order[i]} pos")
+        plt.plot(t.cpu().numpy(), dof_target_pos_buffer[:, i].cpu().numpy(), label=f"{joint_order[i]} target", linestyle='dashed')
+        plt.title(f"Joint {joint_order[i]} Trajectory")
+        plt.xlabel("Time [s]")
+        plt.ylabel("Joint position [rad]")
+        plt.grid()
+        plt.legend()
+        plt.tight_layout()
+        plt.show()
+
+
+if __name__ == "__main__":
+    # run the main function
+    main()
+    # close sim app
+    simulation_app.close()

--- a/scripts/pace/data_collection.py
+++ b/scripts/pace/data_collection.py
@@ -106,7 +106,7 @@ def main():
         [1.0, 1.0, 1.0, -1.0, 1.0, 1.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0],
         device=env.unwrapped.device
     )
-    # APPEND_PLACEHOLDER
+
     trajectory_bias = torch.tensor(
         [0.0, 0.4, 0.8] * 4,
         device=env.unwrapped.device

--- a/scripts/pace/data_collection.py
+++ b/scripts/pace/data_collection.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024-2026 Ziqi Fan
+# SPDX-License-Identifier: Apache-2.0
+
 # © 2025 ETH Zurich, Robotic Systems Lab
 # Author: Filip Bjelonic
 # Licensed under the Apache License 2.0
@@ -29,21 +32,18 @@ simulation_app = app_launcher.app
 """Rest everything follows."""
 
 import gymnasium as gym
+import robot_lab.tasks  # noqa: F401
 import torch
+from robot_lab.utils.paths import project_root
+from torch import pi
 
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.utils import parse_env_cfg
-from torch import pi
-
-import robot_lab.tasks  # noqa: F401
-from robot_lab.utils.paths import project_root
 
 
 def main():
     # parse configuration
-    env_cfg = parse_env_cfg(
-        args_cli.task, device=args_cli.device, num_envs=args_cli.num_envs
-    )
+    env_cfg = parse_env_cfg(args_cli.task, device=args_cli.device, num_envs=args_cli.num_envs)
     # create environment
     env = gym.make(args_cli.task, cfg=env_cfg)
 
@@ -55,7 +55,9 @@ def main():
     articulation = env.unwrapped.scene["robot"]
 
     joint_order = env_cfg.sim2real.joint_order
-    joint_ids = torch.tensor([articulation.joint_names.index(name) for name in joint_order], device=env.unwrapped.device)
+    joint_ids = torch.tensor(
+        [articulation.joint_names.index(name) for name in joint_order], device=env.unwrapped.device
+    )
 
     armature = torch.tensor([0.1] * len(joint_ids), device=env.unwrapped.device).unsqueeze(0)
     damping = torch.tensor([4.5] * len(joint_ids), device=env.unwrapped.device).unsqueeze(0)
@@ -66,12 +68,16 @@ def main():
 
     articulation.write_joint_armature_to_sim(armature, joint_ids=joint_ids, env_ids=torch.arange(len(armature)))
     articulation.data.default_joint_armature[:, joint_ids] = armature
-    articulation.write_joint_viscous_friction_coefficient_to_sim(damping, joint_ids=joint_ids, env_ids=torch.arange(len(damping)))
+    articulation.write_joint_viscous_friction_coefficient_to_sim(
+        damping, joint_ids=joint_ids, env_ids=torch.arange(len(damping))
+    )
     articulation.data.default_joint_viscous_friction_coeff[:, joint_ids] = damping
     # note: modeling coulomb friction if joint_friction = joint_dynamic_friction
     articulation.write_joint_friction_coefficient_to_sim(friction, joint_ids=joint_ids, env_ids=torch.tensor([0]))
     articulation.data.default_joint_friction_coeff[:, joint_ids] = friction
-    articulation.write_joint_dynamic_friction_coefficient_to_sim(friction, joint_ids=joint_ids, env_ids=torch.tensor([0]))
+    articulation.write_joint_dynamic_friction_coefficient_to_sim(
+        friction, joint_ids=joint_ids, env_ids=torch.tensor([0])
+    )
     articulation.data.default_joint_dynamic_friction_coeff[:, joint_ids] = friction
     drive_types = articulation.actuators.keys()
     for drive_type in drive_types:
@@ -79,7 +85,7 @@ def main():
         if isinstance(drive_indices, slice):
             all_idx = torch.arange(joint_ids.shape[0], device=joint_ids.device)
             drive_indices = all_idx[drive_indices]
-        comparison_matrix = (joint_ids.unsqueeze(1) == drive_indices.unsqueeze(0))
+        comparison_matrix = joint_ids.unsqueeze(1) == drive_indices.unsqueeze(0)
         drive_joint_idx = torch.argmax(comparison_matrix.int(), dim=0)
         articulation.actuators[drive_type].update_time_lags(time_lag)
         articulation.actuators[drive_type].update_encoder_bias(bias[:, drive_joint_idx])
@@ -97,25 +103,22 @@ def main():
     f1 = args_cli.max_frequency  # Hz
 
     # Linear chirp: phase = 2*pi*(f0*t + (f1-f0)/(2*duration)*t^2)
-    phase = 2 * pi * (f0 * t + ((f1 - f0) / (2 * duration)) * t ** 2)
+    phase = 2 * pi * (f0 * t + ((f1 - f0) / (2 * duration)) * t**2)
     chirp_signal = torch.sin(phase)
 
     trajectory = torch.zeros((num_steps, len(joint_ids)), device=env.unwrapped.device)
     trajectory[:, :] = chirp_signal.unsqueeze(-1)
     trajectory_directions = torch.tensor(
-        [1.0, 1.0, 1.0, -1.0, 1.0, 1.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0],
-        device=env.unwrapped.device
+        [1.0, 1.0, 1.0, -1.0, 1.0, 1.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0], device=env.unwrapped.device
     )
 
-    trajectory_bias = torch.tensor(
-        [0.0, 0.4, 0.8] * 4,
-        device=env.unwrapped.device
+    trajectory_bias = torch.tensor([0.0, 0.4, 0.8] * 4, device=env.unwrapped.device)
+    trajectory_scale = torch.tensor([0.25, 0.5, -2.0] * 4, device=env.unwrapped.device)
+    trajectory[:, joint_ids] = (
+        (trajectory[:, joint_ids] + trajectory_bias.unsqueeze(0))
+        * trajectory_directions.unsqueeze(0)
+        * trajectory_scale.unsqueeze(0)
     )
-    trajectory_scale = torch.tensor(
-        [0.25, 0.5, -2.0] * 4,
-        device=env.unwrapped.device
-    )
-    trajectory[:, joint_ids] = (trajectory[:, joint_ids] + trajectory_bias.unsqueeze(0)) * trajectory_directions.unsqueeze(0) * trajectory_scale.unsqueeze(0)
 
     articulation.write_joint_position_to_sim(trajectory[0, :].unsqueeze(0) + bias[0, joint_ids])
     articulation.write_joint_velocity_to_sim(torch.zeros((1, len(joint_ids)), device=env.unwrapped.device))
@@ -129,15 +132,19 @@ def main():
         # run everything in inference mode
         with torch.inference_mode():
             # compute actions
-            dof_pos_buffer[counter, :] = env.unwrapped.scene.articulations["robot"].data.joint_pos[0, joint_ids] - bias[0]
+            dof_pos_buffer[counter, :] = (
+                env.unwrapped.scene.articulations["robot"].data.joint_pos[0, joint_ids] - bias[0]
+            )
             actions = torch.zeros(env.action_space.shape, device=env.unwrapped.device)
             actions = trajectory[counter % num_steps, :].unsqueeze(0).repeat(env.unwrapped.num_envs, 1)
             # apply actions
             obs, _, _, _, _ = env.step(actions)
-            dof_target_pos_buffer[counter, :] = env.unwrapped.scene.articulations["robot"]._data.joint_pos_target[0, joint_ids]
+            dof_target_pos_buffer[counter, :] = env.unwrapped.scene.articulations["robot"]._data.joint_pos_target[
+                0, joint_ids
+            ]
             counter += 1
             if counter % 400 == 0:
-                print(f"[INFO]: Step {counter/sample_rate} seconds")
+                print(f"[INFO]: Step {counter / sample_rate} seconds")
             if counter >= num_steps:
                 break
 
@@ -145,21 +152,30 @@ def main():
     env.close()
 
     from time import sleep
+
     sleep(1)  # wait a bit for everything to settle
 
     (data_dir).mkdir(parents=True, exist_ok=True)
-    torch.save({
-        "time": time_data.cpu(),
-        "dof_pos": dof_pos_buffer.cpu(),
-        "des_dof_pos": dof_target_pos_buffer.cpu(),
-    }, data_dir / "chirp_data.pt")
+    torch.save(
+        {
+            "time": time_data.cpu(),
+            "dof_pos": dof_pos_buffer.cpu(),
+            "des_dof_pos": dof_target_pos_buffer.cpu(),
+        },
+        data_dir / "chirp_data.pt",
+    )
 
     import matplotlib.pyplot as plt
 
     for i in range(len(joint_ids)):
         plt.figure()
         plt.plot(t.cpu().numpy(), dof_pos_buffer[:, i].cpu().numpy(), label=f"{joint_order[i]} pos")
-        plt.plot(t.cpu().numpy(), dof_target_pos_buffer[:, i].cpu().numpy(), label=f"{joint_order[i]} target", linestyle='dashed')
+        plt.plot(
+            t.cpu().numpy(),
+            dof_target_pos_buffer[:, i].cpu().numpy(),
+            label=f"{joint_order[i]} target",
+            linestyle="dashed",
+        )
         plt.title(f"Joint {joint_order[i]} Trajectory")
         plt.xlabel("Time [s]")
         plt.ylabel("Joint position [rad]")

--- a/scripts/pace/fit.py
+++ b/scripts/pace/fit.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024-2026 Ziqi Fan
+# SPDX-License-Identifier: Apache-2.0
+
 # © 2025 ETH Zurich, Robotic Systems Lab
 # Author: Filip Bjelonic
 # Licensed under the Apache License 2.0
@@ -26,22 +29,19 @@ simulation_app = app_launcher.app
 """Rest everything follows."""
 
 import gymnasium as gym
+import robot_lab.tasks  # noqa: F401
 import torch
+from robot_lab.tasks.manager_based.pace.optim import CMAESOptimizer
+from robot_lab.utils.paths import project_root
 
 import isaaclab_tasks  # noqa: F401
 from isaaclab_tasks.utils import parse_env_cfg
-
-import robot_lab.tasks  # noqa: F401
-from robot_lab.utils.paths import project_root
-from robot_lab.tasks.manager_based.pace.optim import CMAESOptimizer
 
 
 def main():
     """Zero actions agent with Isaac Lab environment."""
     # parse configuration
-    env_cfg = parse_env_cfg(
-        args_cli.task, device=args_cli.device, num_envs=args_cli.num_envs
-    )
+    env_cfg = parse_env_cfg(args_cli.task, device=args_cli.device, num_envs=args_cli.num_envs)
     # create environment
     env = gym.make(args_cli.task, cfg=env_cfg)
 
@@ -53,7 +53,9 @@ def main():
     bounds_params = env_cfg.sim2real.bounds_params.to(env.unwrapped.device)
     articulation = env.unwrapped.scene["robot"]
     joint_order = env_cfg.sim2real.joint_order
-    sim_joint_ids = torch.tensor([articulation.joint_names.index(name) for name in joint_order], device=env.unwrapped.device)
+    sim_joint_ids = torch.tensor(
+        [articulation.joint_names.index(name) for name in joint_order], device=env.unwrapped.device
+    )
 
     data_file = project_root() / "data" / env_cfg.sim2real.data_dir
     log_dir = project_root() / "logs" / "pace" / env_cfg.sim2real.robot_name
@@ -91,14 +93,20 @@ def main():
         # run everything in inference mode
         with torch.inference_mode():
             # compute zero actions
-            opt.tell(env.unwrapped.scene.articulations["robot"].data.joint_pos[:, sim_joint_ids], measured_dof_pos[counter, :].unsqueeze(0).repeat(env.unwrapped.num_envs, 1))
+            opt.tell(
+                env.unwrapped.scene.articulations["robot"].data.joint_pos[:, sim_joint_ids],
+                measured_dof_pos[counter, :].unsqueeze(0).repeat(env.unwrapped.num_envs, 1),
+            )
             actions = torch.zeros(env.action_space.shape, device=env.unwrapped.device)
             actions[:, sim_joint_ids] = target_dof_pos[counter, :].unsqueeze(0).repeat(env.unwrapped.num_envs, 1)
             # apply actions
             env.step(actions)
             counter += 1
             if counter % 400 == 0:
-                print(f"[INFO]: Step {counter * sim_dt:.1f} / {time_data[-1]:.1f} seconds ({counter / time_steps * 100:.1f} %)")
+                print(
+                    f"[INFO]: Step {counter * sim_dt:.1f} / {time_data[-1]:.1f} seconds"
+                    f" ({counter / time_steps * 100:.1f} %)"
+                )
             if counter >= time_steps:
                 print("[INFO]: Reached the end of the trajectory, exiting.")
                 counter = 0

--- a/scripts/pace/fit.py
+++ b/scripts/pace/fit.py
@@ -1,0 +1,120 @@
+# © 2025 ETH Zurich, Robotic Systems Lab
+# Author: Filip Bjelonic
+# Licensed under the Apache License 2.0
+
+"""Script to run PACE CMA-ES parameter fitting."""
+
+"""Launch Isaac Sim Simulator first."""
+
+import argparse
+
+from isaaclab.app import AppLauncher
+
+# add argparse arguments
+parser = argparse.ArgumentParser(description="Pace agent for Isaac Lab environments.")
+parser.add_argument("--num_envs", type=int, default=4096, help="Number of environments to simulate.")
+parser.add_argument("--task", type=str, default="Isaac-Pace-Anymal-D-v0", help="Name of the task.")
+# append AppLauncher cli args
+AppLauncher.add_app_launcher_args(parser)
+# parse the arguments
+args_cli = parser.parse_args()
+
+# launch omniverse app
+app_launcher = AppLauncher(args_cli)
+simulation_app = app_launcher.app
+
+"""Rest everything follows."""
+
+import gymnasium as gym
+import torch
+
+import isaaclab_tasks  # noqa: F401
+from isaaclab_tasks.utils import parse_env_cfg
+
+import robot_lab.tasks  # noqa: F401
+from robot_lab.utils.paths import project_root
+from robot_lab.tasks.manager_based.pace.optim import CMAESOptimizer
+
+
+def main():
+    """Zero actions agent with Isaac Lab environment."""
+    # parse configuration
+    env_cfg = parse_env_cfg(
+        args_cli.task, device=args_cli.device, num_envs=args_cli.num_envs
+    )
+    # create environment
+    env = gym.make(args_cli.task, cfg=env_cfg)
+
+    # print info (this is vectorized environment)
+    print(f"[INFO]: Gym observation space: {env.observation_space}")
+    print(f"[INFO]: Gym action space: {env.action_space}")
+
+    # Create optimization
+    bounds_params = env_cfg.sim2real.bounds_params.to(env.unwrapped.device)
+    articulation = env.unwrapped.scene["robot"]
+    joint_order = env_cfg.sim2real.joint_order
+    sim_joint_ids = torch.tensor([articulation.joint_names.index(name) for name in joint_order], device=env.unwrapped.device)
+
+    data_file = project_root() / "data" / env_cfg.sim2real.data_dir
+    log_dir = project_root() / "logs" / "pace" / env_cfg.sim2real.robot_name
+
+    data = torch.load(data_file)
+    time_data = data["time"].to(env.unwrapped.device)
+    target_dof_pos = data["des_dof_pos"].to(env.unwrapped.device)
+    measured_dof_pos = data["dof_pos"].to(env.unwrapped.device)
+
+    initial_dof_pos = measured_dof_pos[0, :].unsqueeze(0).repeat(env.unwrapped.num_envs, 1)
+
+    time_steps = time_data.shape[0]
+    sim_dt = env.unwrapped.sim.cfg.dt
+    # APPEND_FIT
+    opt = CMAESOptimizer(
+        bounds=bounds_params,
+        population_size=env.unwrapped.num_envs,
+        log_dir=log_dir,
+        joint_order=joint_order,
+        max_iteration=env_cfg.sim2real.cmaes.max_iteration,
+        data=data,
+        device=env.unwrapped.device,
+        epsilon=env_cfg.sim2real.cmaes.epsilon,
+        sigma=env_cfg.sim2real.cmaes.sigma,
+        save_interval=env_cfg.sim2real.cmaes.save_interval,
+        save_optimization_process=env_cfg.sim2real.cmaes.save_optimization_process,
+    )
+
+    env.reset()
+    opt.update_simulator(articulation, sim_joint_ids, initial_dof_pos)
+
+    counter = 0
+    # simulate environment
+    while simulation_app.is_running():
+        # run everything in inference mode
+        with torch.inference_mode():
+            # compute zero actions
+            opt.tell(env.unwrapped.scene.articulations["robot"].data.joint_pos[:, sim_joint_ids], measured_dof_pos[counter, :].unsqueeze(0).repeat(env.unwrapped.num_envs, 1))
+            actions = torch.zeros(env.action_space.shape, device=env.unwrapped.device)
+            actions[:, sim_joint_ids] = target_dof_pos[counter, :].unsqueeze(0).repeat(env.unwrapped.num_envs, 1)
+            # apply actions
+            env.step(actions)
+            counter += 1
+            if counter % 400 == 0:
+                print(f"[INFO]: Step {counter * sim_dt:.1f} / {time_data[-1]:.1f} seconds ({counter / time_steps * 100:.1f} %)")
+            if counter >= time_steps:
+                print("[INFO]: Reached the end of the trajectory, exiting.")
+                counter = 0
+                opt.evolve()
+                if opt.finished():
+                    break
+                env.reset()
+                opt.update_simulator(env.unwrapped.scene["robot"], sim_joint_ids, initial_dof_pos)
+    # close optimizer
+    opt.close()
+    # close the simulator
+    env.close()
+
+
+if __name__ == "__main__":
+    # run the main function
+    main()
+    # close sim app
+    simulation_app.close()

--- a/scripts/pace/fit.py
+++ b/scripts/pace/fit.py
@@ -67,7 +67,7 @@ def main():
 
     time_steps = time_data.shape[0]
     sim_dt = env.unwrapped.sim.cfg.dt
-    # APPEND_FIT
+
     opt = CMAESOptimizer(
         bounds=bounds_params,
         population_size=env.unwrapped.num_envs,

--- a/scripts/pace/plot_trajectory.py
+++ b/scripts/pace/plot_trajectory.py
@@ -106,7 +106,7 @@ if plot_score:
     # plt.ylim(0, None)
     plt.grid()
     plt.show()
-# APPEND_PLOT
+
 if plot_trajectory:
     for i in range(len(joint_order)):
         plt.figure(figsize=(8, 4.5))

--- a/scripts/pace/plot_trajectory.py
+++ b/scripts/pace/plot_trajectory.py
@@ -1,14 +1,16 @@
+# Copyright (c) 2024-2026 Ziqi Fan
+# SPDX-License-Identifier: Apache-2.0
+
 # © 2025 ETH Zurich, Robotic Systems Lab
 # Author: Filip Bjelonic
 # Licensed under the Apache License 2.0
 
-import torch
-import matplotlib.pyplot as plt
+import argparse
 import re
 from pathlib import Path
 
-import argparse
-
+import matplotlib.pyplot as plt
+import torch
 from robot_lab.utils.paths import project_root
 
 # add argparse arguments
@@ -79,12 +81,12 @@ target_trajectories = config["des_dof_pos"]  # time x joints
 time = config["time"]  # time
 
 print(f"Best parameter set: {mean}")
-print(f"Armature params: {mean[:len(joint_order)]}")
-print(f"Viscous friction params: {mean[len(joint_order):2 * len(joint_order)]}")
-print(f"Static/dynamic friction params: {mean[2 * len(joint_order):3 * len(joint_order)]}")
-print(f"Encoder bias params: {mean[3 * len(joint_order):4 * len(joint_order)]}")
+print(f"Armature params: {mean[: len(joint_order)]}")
+print(f"Viscous friction params: {mean[len(joint_order) : 2 * len(joint_order)]}")
+print(f"Static/dynamic friction params: {mean[2 * len(joint_order) : 3 * len(joint_order)]}")
+print(f"Encoder bias params: {mean[3 * len(joint_order) : 4 * len(joint_order)]}")
 print(f"Delay param: {mean[-1].item()}")
-encoder_bias = mean[3 * len(joint_order):4 * len(joint_order)]  # extract encoder bias
+encoder_bias = mean[3 * len(joint_order) : 4 * len(joint_order)]  # extract encoder bias
 
 if plot_score:
     try:
@@ -100,7 +102,7 @@ if plot_score:
     plt.title("CMA-ES Score over Iterations")
     plt.xlabel("Iteration")
     plt.ylabel("Score")
-    data = torch.min(progress["scores_buffer"][:params_num + 1], dim=1).values.cpu().numpy()
+    data = torch.min(progress["scores_buffer"][: params_num + 1], dim=1).values.cpu().numpy()
     plt.semilogy(data)
     plt.xlim(0, params_num)
     # plt.ylim(0, None)
@@ -110,7 +112,9 @@ if plot_score:
 if plot_trajectory:
     for i in range(len(joint_order)):
         plt.figure(figsize=(8, 4.5))
-        plt.plot(time, trajectories[:, i].cpu().numpy() - encoder_bias[i].item(), c="tab:orange", label="Sim", linewidth=2)  # in encoder frame
+        plt.plot(
+            time, trajectories[:, i].cpu().numpy() - encoder_bias[i].item(), c="tab:orange", label="Sim", linewidth=2
+        )  # in encoder frame
         plt.plot(time, real_trajectories[:, i].cpu().numpy(), label="Real", c="tab:green", linestyle="--", linewidth=2)
         plt.plot(time, target_trajectories[:, i].cpu().numpy(), c="grey", label="Target", linestyle="--", alpha=0.5)
         plt.title(f"Joint {joint_order[i]}")  # Use joint names from config

--- a/scripts/pace/plot_trajectory.py
+++ b/scripts/pace/plot_trajectory.py
@@ -1,0 +1,124 @@
+# © 2025 ETH Zurich, Robotic Systems Lab
+# Author: Filip Bjelonic
+# Licensed under the Apache License 2.0
+
+import torch
+import matplotlib.pyplot as plt
+import re
+from pathlib import Path
+
+import argparse
+
+from robot_lab.utils.paths import project_root
+
+# add argparse arguments
+parser = argparse.ArgumentParser(description="Pace agent for Isaac Lab environments.")
+parser.add_argument("--folder_name", type=str, default=None, help="Name of the folder to use.")
+parser.add_argument("--mean_name", type=str, default=None, help="Name of the parameters file to use.")
+parser.add_argument("--robot_name", type=str, default="anymal_d_sim", help="Name of the robot.")
+parser.add_argument("--plot_trajectory", action="store_true", help="Whether to plot the trajectory.")
+parser.add_argument("--plot_score", action="store_true", help="Whether to plot the score over iterations.")
+
+args = parser.parse_args()
+folder_name = args.folder_name
+mean_name = args.mean_name
+robot_name = args.robot_name
+plot_trajectory = args.plot_trajectory
+plot_score = args.plot_score
+
+log_dir = project_root() / "logs" / "pace" / robot_name
+
+if not log_dir.exists():
+    raise FileNotFoundError(f"No logs for robot {robot_name} under {log_dir}")
+
+_pattern = re.compile(r"^mean_(\d+)\.pt$")
+
+
+def find_latest_params(root: Path):
+    best = None  # tuple (int, Path)
+    for p in root.rglob("mean_*.pt"):
+        m = _pattern.match(p.name)
+        if not m:
+            continue
+        num = int(m.group(1))
+        if best is None or num > best[0]:
+            best = (num, p)
+    return None if best is None else best[1], best[0]
+
+
+# if no folder_name given, pick the most recent run folder for the robot
+if not folder_name:
+    robot_dir = log_dir
+    candidates = [p for p in robot_dir.iterdir() if p.is_dir()]
+    if not candidates:
+        raise FileNotFoundError(f"No run folders found under {robot_dir}")
+    latest_folder = max(candidates, key=lambda p: p.stat().st_mtime)
+    folder_name = latest_folder.name
+
+# now point log_dir at the chosen robot/run folder
+log_dir = log_dir / folder_name
+
+if mean_name is None:
+    params_path, params_num = find_latest_params(log_dir)
+else:
+    params_path = log_dir / mean_name
+    params_num = int(_pattern.match(mean_name).group(1))
+    if not params_path.exists():
+        raise FileNotFoundError(f"Given params file {params_path} does not exist")
+if params_path is None:
+    raise FileNotFoundError(f"No mean_*.pt files found under {log_dir}")
+print(f"Latest params file: {params_path}")
+
+mean = torch.load(params_path)
+config = torch.load(log_dir / "config.pt")
+
+joint_order = config["joint_order"]
+trajectories = torch.load(log_dir / "best_trajectory.pt")  # time x joints
+real_trajectories = config["dof_pos"]  # time x joints
+target_trajectories = config["des_dof_pos"]  # time x joints
+time = config["time"]  # time
+
+print(f"Best parameter set: {mean}")
+print(f"Armature params: {mean[:len(joint_order)]}")
+print(f"Viscous friction params: {mean[len(joint_order):2 * len(joint_order)]}")
+print(f"Static/dynamic friction params: {mean[2 * len(joint_order):3 * len(joint_order)]}")
+print(f"Encoder bias params: {mean[3 * len(joint_order):4 * len(joint_order)]}")
+print(f"Delay param: {mean[-1].item()}")
+encoder_bias = mean[3 * len(joint_order):4 * len(joint_order)]  # extract encoder bias
+
+if plot_score:
+    try:
+        progress = torch.load(log_dir / "progress.pt")
+        print("Loaded optimization progress.")
+    except FileNotFoundError:
+        progress = None
+        print("No optimization progress file found. Skipping score plot.")
+        plot_score = False
+
+if plot_score:
+    plt.figure()
+    plt.title("CMA-ES Score over Iterations")
+    plt.xlabel("Iteration")
+    plt.ylabel("Score")
+    data = torch.min(progress["scores_buffer"][:params_num + 1], dim=1).values.cpu().numpy()
+    plt.semilogy(data)
+    plt.xlim(0, params_num)
+    # plt.ylim(0, None)
+    plt.grid()
+    plt.show()
+# APPEND_PLOT
+if plot_trajectory:
+    for i in range(len(joint_order)):
+        plt.figure(figsize=(8, 4.5))
+        plt.plot(time, trajectories[:, i].cpu().numpy() - encoder_bias[i].item(), c="tab:orange", label="Sim", linewidth=2)  # in encoder frame
+        plt.plot(time, real_trajectories[:, i].cpu().numpy(), label="Real", c="tab:green", linestyle="--", linewidth=2)
+        plt.plot(time, target_trajectories[:, i].cpu().numpy(), c="grey", label="Target", linestyle="--", alpha=0.5)
+        plt.title(f"Joint {joint_order[i]}")  # Use joint names from config
+        plt.xlabel("Time [s]")
+        plt.ylabel("Joint position [rad]")
+        plt.legend()
+        plt.grid()
+        plt.tight_layout()
+        plt.show()
+
+print("Plotting complete.")

--- a/scripts/pace/plot_trajectory.py
+++ b/scripts/pace/plot_trajectory.py
@@ -11,7 +11,11 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 import torch
-from robot_lab.utils.paths import project_root
+
+# Resolve project root from this script's location instead of importing
+# robot_lab.utils.paths, which would pull in the full IsaacLab task registry
+# and require launching the Isaac Sim app for an offline plotting tool.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
 # add argparse arguments
 parser = argparse.ArgumentParser(description="Pace agent for Isaac Lab environments.")
@@ -28,7 +32,7 @@ robot_name = args.robot_name
 plot_trajectory = args.plot_trajectory
 plot_score = args.plot_score
 
-log_dir = project_root() / "logs" / "pace" / robot_name
+log_dir = _PROJECT_ROOT / "logs" / "pace" / robot_name
 
 if not log_dir.exists():
     raise FileNotFoundError(f"No logs for robot {robot_name} under {log_dir}")

--- a/source/robot_lab/robot_lab/actuators/__init__.py
+++ b/source/robot_lab/robot_lab/actuators/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2024-2026 Ziqi Fan
+# SPDX-License-Identifier: Apache-2.0
+
+"""Custom actuator models used by robot_lab tasks.
+
+PACE actuator model: see pace_actuator.py / pace_actuator_cfg.py.
+"""
+
+from . import pace_actuator
+from .pace_actuator import PaceDCMotor
+from .pace_actuator_cfg import PaceDCMotorCfg
+
+__all__ = [
+    "PaceDCMotor",
+    "PaceDCMotorCfg",
+    "pace_actuator",
+]

--- a/source/robot_lab/robot_lab/actuators/pace_actuator.py
+++ b/source/robot_lab/robot_lab/actuators/pace_actuator.py
@@ -1,0 +1,66 @@
+# © 2025 ETH Zurich, Robotic Systems Lab
+# Author: Filip Bjelonic
+# Licensed under the Apache License 2.0
+
+from __future__ import annotations
+
+import torch
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from isaaclab.actuators import DCMotor
+from isaaclab.utils.types import ArticulationActions
+from isaaclab.utils import DelayBuffer
+if TYPE_CHECKING:
+    # only for type checking
+    from .pace_actuator_cfg import PaceDCMotorCfg
+
+
+class PaceDCMotor(DCMotor):
+    """Pace DC Motor actuator model with encoder bias and action delay.
+
+    The actuator models a DC motor whose controller receives joint positions in the encoder
+    frame by adding a per-joint encoder bias to the true joint positions. In other words,
+    the controller operates on biased (encoder) positions rather than the true joint positions.
+
+    The torque command computed by the PD controller is applied after a configurable delay
+    (in simulation steps) to represent latency between command calculation and actuation.
+
+    The software implementation is inspired by DelayedPDActuator.
+    """
+
+    cfg: PaceDCMotorCfg
+
+    def __init__(self, cfg: PaceDCMotorCfg, *args, **kwargs):
+        super().__init__(cfg, *args, **kwargs)
+        if isinstance(cfg.encoder_bias, (list, tuple)):
+            if len(cfg.encoder_bias) != self.num_joints:
+                raise ValueError(
+                    f"encoder_bias must have {self.num_joints} elements (one per joint), "
+                    f"but got {len(cfg.encoder_bias)}: {cfg.encoder_bias}"
+                )
+        self.encoder_bias = self._parse_joint_parameter(cfg.encoder_bias, 0.0)
+
+        self.torques_delay_buffer = DelayBuffer(cfg.max_delay + 1, self._num_envs, device=self._device)
+        self.torques_delay_buffer.set_time_lag(cfg.max_delay, torch.arange(self._num_envs, device=self._device))
+
+    def reset(self, env_ids: Sequence[int]):
+        super().reset(env_ids)
+        # reset buffers
+        self.torques_delay_buffer.reset(env_ids)
+
+    def update_encoder_bias(self, encoder_bias: torch.Tensor):
+        self.encoder_bias = encoder_bias
+
+    def update_time_lags(self, delay: int | torch.Tensor, env_ids: Sequence[int] | None = None):
+        if env_ids is None:
+            env_ids = torch.arange(self._num_envs, device=self._device)
+        self.torques_delay_buffer.set_time_lag(delay, env_ids)
+
+    def compute(
+        self, control_action: ArticulationActions, joint_pos: torch.Tensor, joint_vel: torch.Tensor
+    ) -> ArticulationActions:
+        # compute actuator model with encoder bias added to joint positions (joint position in encoder frame, not simulation frame)
+        control_action_sim = super().compute(control_action, joint_pos - self.encoder_bias, joint_vel)
+        control_action_sim.joint_efforts = self.torques_delay_buffer.compute(control_action_sim.joint_efforts)
+        return control_action_sim

--- a/source/robot_lab/robot_lab/actuators/pace_actuator.py
+++ b/source/robot_lab/robot_lab/actuators/pace_actuator.py
@@ -1,16 +1,21 @@
+# Copyright (c) 2024-2026 Ziqi Fan
+# SPDX-License-Identifier: Apache-2.0
+
 # © 2025 ETH Zurich, Robotic Systems Lab
 # Author: Filip Bjelonic
 # Licensed under the Apache License 2.0
 
 from __future__ import annotations
 
-import torch
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
+import torch
+
 from isaaclab.actuators import DCMotor
-from isaaclab.utils.types import ArticulationActions
 from isaaclab.utils import DelayBuffer
+from isaaclab.utils.types import ArticulationActions
+
 if TYPE_CHECKING:
     # only for type checking
     from .pace_actuator_cfg import PaceDCMotorCfg
@@ -60,7 +65,8 @@ class PaceDCMotor(DCMotor):
     def compute(
         self, control_action: ArticulationActions, joint_pos: torch.Tensor, joint_vel: torch.Tensor
     ) -> ArticulationActions:
-        # compute actuator model with encoder bias added to joint positions (joint position in encoder frame, not simulation frame)
+        # compute actuator model with encoder bias added to joint positions
+        # (joint position in encoder frame, not simulation frame)
         control_action_sim = super().compute(control_action, joint_pos - self.encoder_bias, joint_vel)
         control_action_sim.joint_efforts = self.torques_delay_buffer.compute(control_action_sim.joint_efforts)
         return control_action_sim

--- a/source/robot_lab/robot_lab/actuators/pace_actuator_cfg.py
+++ b/source/robot_lab/robot_lab/actuators/pace_actuator_cfg.py
@@ -1,13 +1,17 @@
+# Copyright (c) 2024-2026 Ziqi Fan
+# SPDX-License-Identifier: Apache-2.0
+
 # © 2025 ETH Zurich, Robotic Systems Lab
 # Author: Filip Bjelonic
 # Licensed under the Apache License 2.0
 
 from __future__ import annotations
+
 import torch
 
+from isaaclab.actuators import DCMotorCfg
 from isaaclab.utils import configclass
 
-from isaaclab.actuators import DCMotorCfg
 from robot_lab.actuators import pace_actuator
 
 
@@ -17,6 +21,7 @@ class PaceDCMotorCfg(DCMotorCfg):
 
     This class extends the base DCMotorCfg with Pace-specific parameters.
     """
+
     class_type: type = pace_actuator.PaceDCMotor
     encoder_bias: dict[str, float] | float | None = 0.0
     max_delay: torch.int | None = 0

--- a/source/robot_lab/robot_lab/actuators/pace_actuator_cfg.py
+++ b/source/robot_lab/robot_lab/actuators/pace_actuator_cfg.py
@@ -1,0 +1,22 @@
+# © 2025 ETH Zurich, Robotic Systems Lab
+# Author: Filip Bjelonic
+# Licensed under the Apache License 2.0
+
+from __future__ import annotations
+import torch
+
+from isaaclab.utils import configclass
+
+from isaaclab.actuators import DCMotorCfg
+from robot_lab.actuators import pace_actuator
+
+
+@configclass
+class PaceDCMotorCfg(DCMotorCfg):
+    """Configuration for Pace DC Motor actuator model.
+
+    This class extends the base DCMotorCfg with Pace-specific parameters.
+    """
+    class_type: type = pace_actuator.PaceDCMotor
+    encoder_bias: dict[str, float] | float | None = 0.0
+    max_delay: torch.int | None = 0

--- a/source/robot_lab/robot_lab/tasks/manager_based/pace/__init__.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/pace/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024-2026 Ziqi Fan
+# SPDX-License-Identifier: Apache-2.0
+
+"""PACE — Precise Adaptation through Continuous Evolution.
+
+System identification tasks that estimate actuator and joint dynamics from
+chirp-excitation data using CMA-ES. See robot_lab/tasks/manager_based/pace/
+config/<robot>/ for per-robot demo tasks.
+"""

--- a/source/robot_lab/robot_lab/tasks/manager_based/pace/agents/__init__.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/pace/agents/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause

--- a/source/robot_lab/robot_lab/tasks/manager_based/pace/agents/__init__.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/pace/agents/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024-2026 Ziqi Fan
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #

--- a/source/robot_lab/robot_lab/tasks/manager_based/pace/agents/rsl_rl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/pace/agents/rsl_rl_ppo_cfg.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from isaaclab.utils import configclass
+
+from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg
+
+
+@configclass
+class PPORunnerCfg(RslRlOnPolicyRunnerCfg):
+    num_steps_per_env = 16
+    max_iterations = 150
+    save_interval = 50
+    experiment_name = "cartpole_direct"
+    policy = RslRlPpoActorCriticCfg(
+        init_noise_std=1.0,
+        actor_obs_normalization=False,
+        critic_obs_normalization=False,
+        actor_hidden_dims=[32, 32],
+        critic_hidden_dims=[32, 32],
+        activation="elu",
+    )
+    algorithm = RslRlPpoAlgorithmCfg(
+        value_loss_coef=1.0,
+        use_clipped_value_loss=True,
+        clip_param=0.2,
+        entropy_coef=0.005,
+        num_learning_epochs=5,
+        num_mini_batches=4,
+        learning_rate=1.0e-3,
+        schedule="adaptive",
+        gamma=0.99,
+        lam=0.95,
+        desired_kl=0.01,
+        max_grad_norm=1.0,
+    )

--- a/source/robot_lab/robot_lab/tasks/manager_based/pace/agents/rsl_rl_ppo_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/pace/agents/rsl_rl_ppo_cfg.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024-2026 Ziqi Fan
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #

--- a/source/robot_lab/robot_lab/tasks/manager_based/pace/config/__init__.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/pace/config/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024-2026 Ziqi Fan
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-robot PACE task configurations.
+
+We leave this file (almost) empty since we don't want to expose any configs in
+this package directly. We still need it so the parent package can import the
+sub-modules through ``isaaclab_tasks.utils.import_packages``.
+"""

--- a/source/robot_lab/robot_lab/tasks/manager_based/pace/config/anymal_d/__init__.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/pace/config/anymal_d/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2024-2026 Ziqi Fan
+# SPDX-License-Identifier: Apache-2.0
+
+import gymnasium as gym
+
+from . import agents
+
+##
+# Register Gym environments.
+##
+
+gym.register(
+    id="Isaac-Pace-Anymal-D-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.pace_env_cfg:AnymalDPaceEnvCfg",
+    },
+)

--- a/source/robot_lab/robot_lab/tasks/manager_based/pace/config/anymal_d/agents/__init__.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/pace/config/anymal_d/agents/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2024-2026 Ziqi Fan
+# SPDX-License-Identifier: Apache-2.0

--- a/source/robot_lab/robot_lab/tasks/manager_based/pace/config/anymal_d/pace_env_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/pace/config/anymal_d/pace_env_cfg.py
@@ -1,18 +1,23 @@
+# Copyright (c) 2024-2026 Ziqi Fan
+# SPDX-License-Identifier: Apache-2.0
+
 # © 2025 ETH Zurich, Robotic Systems Lab
 # Author: Filip Bjelonic
 # Licensed under the Apache License 2.0
 
+import torch
+
+from isaaclab.assets import ArticulationCfg
 from isaaclab.utils import configclass
 
 from isaaclab_assets.robots.anymal import ANYMAL_D_CFG
-from isaaclab.assets import ArticulationCfg
+
 from robot_lab.actuators import PaceDCMotorCfg
 from robot_lab.tasks.manager_based.pace.pace_sim2real_env_cfg import (
+    PaceCfg,
     PaceSim2realEnvCfg,
     PaceSim2realSceneCfg,
-    PaceCfg,
 )
-import torch
 
 ANYDRIVE_PACE_ACTUATOR_CFG = PaceDCMotorCfg(
     joint_names_expr=[".*HAA", ".*HFE", ".*KFE"],
@@ -34,6 +39,7 @@ ANYDRIVE_PACE_ACTUATOR_CFG = PaceDCMotorCfg(
 @configclass
 class AnymalDPaceCfg(PaceCfg):
     """Pace configuration for Anymal-D robot."""
+
     robot_name: str = "anymal_d_sim"
     data_dir: str = "anymal_d_sim/chirp_data.pt"  # located in <project_root>/data/anymal_d_sim/chirp_data.pt
     bounds_params: torch.Tensor = torch.zeros((49, 2))  # 12 + 12 + 12 + 12 + 1 = 49 parameters to optimize
@@ -66,6 +72,7 @@ class AnymalDPaceCfg(PaceCfg):
 @configclass
 class ANYmalDPaceSceneCfg(PaceSim2realSceneCfg):
     """Configuration for Anymal-D robot in Pace Sim2Real environment."""
+
     robot: ArticulationCfg = ANYMAL_D_CFG.replace(
         prim_path="{ENV_REGEX_NS}/Robot",
         init_state=ArticulationCfg.InitialStateCfg(pos=(0.0, 0.0, 1.0)),
@@ -75,7 +82,6 @@ class ANYmalDPaceSceneCfg(PaceSim2realSceneCfg):
 
 @configclass
 class AnymalDPaceEnvCfg(PaceSim2realEnvCfg):
-
     scene: ANYmalDPaceSceneCfg = ANYmalDPaceSceneCfg()
     sim2real: PaceCfg = AnymalDPaceCfg()
 

--- a/source/robot_lab/robot_lab/tasks/manager_based/pace/config/anymal_d/pace_env_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/pace/config/anymal_d/pace_env_cfg.py
@@ -1,0 +1,88 @@
+# © 2025 ETH Zurich, Robotic Systems Lab
+# Author: Filip Bjelonic
+# Licensed under the Apache License 2.0
+
+from isaaclab.utils import configclass
+
+from isaaclab_assets.robots.anymal import ANYMAL_D_CFG
+from isaaclab.assets import ArticulationCfg
+from robot_lab.actuators import PaceDCMotorCfg
+from robot_lab.tasks.manager_based.pace.pace_sim2real_env_cfg import (
+    PaceSim2realEnvCfg,
+    PaceSim2realSceneCfg,
+    PaceCfg,
+)
+import torch
+
+ANYDRIVE_PACE_ACTUATOR_CFG = PaceDCMotorCfg(
+    joint_names_expr=[".*HAA", ".*HFE", ".*KFE"],
+    saturation_effort=140.0,
+    effort_limit=89.0,
+    velocity_limit=8.5,
+    stiffness={".*": 85.0},  # P gain in Nm/rad
+    damping={".*": 0.6},  # D gain in Nm s/rad
+    encoder_bias={".*": 0.0},  # encoder bias in radians
+    # note: modeling coulomb friction if friction = dynamic_friction
+    # > in newer Isaac Sim versions, friction is renamed to static_friction
+    friction={".*": 0.0},  # static friction coefficient (Nm)
+    dynamic_friction={".*": 0.0},  # dynamic friction coefficient (Nm)
+    viscous_friction={".*": 0.0},  # viscous friction coefficient (Nm s/rad)
+    max_delay=10,  # max delay in simulation steps
+)
+
+
+@configclass
+class AnymalDPaceCfg(PaceCfg):
+    """Pace configuration for Anymal-D robot."""
+    robot_name: str = "anymal_d_sim"
+    data_dir: str = "anymal_d_sim/chirp_data.pt"  # located in <project_root>/data/anymal_d_sim/chirp_data.pt
+    bounds_params: torch.Tensor = torch.zeros((49, 2))  # 12 + 12 + 12 + 12 + 1 = 49 parameters to optimize
+    joint_order: list[str] = [
+        "LF_HAA",
+        "LF_HFE",
+        "LF_KFE",
+        "RF_HAA",
+        "RF_HFE",
+        "RF_KFE",
+        "LH_HAA",
+        "LH_HFE",
+        "LH_KFE",
+        "RH_HAA",
+        "RH_HFE",
+        "RH_KFE",
+    ]
+
+    def __post_init__(self):
+        # set bounds for parameters
+        self.bounds_params[:12, 0] = 1e-5
+        self.bounds_params[:12, 1] = 1.0  # armature between 1e-5 - 1.0 [kgm2]
+        self.bounds_params[12:24, 1] = 7.0  # dof_damping between 0.0 - 7.0 [Nm s/rad]
+        self.bounds_params[24:36, 1] = 0.5  # friction between 0.0 - 0.5
+        self.bounds_params[36:48, 0] = -0.1
+        self.bounds_params[36:48, 1] = 0.1  # bias between -0.1 - 0.1 [rad]
+        self.bounds_params[48, 1] = 10.0  # delay between 0.0 - 10.0 [sim steps]
+
+
+@configclass
+class ANYmalDPaceSceneCfg(PaceSim2realSceneCfg):
+    """Configuration for Anymal-D robot in Pace Sim2Real environment."""
+    robot: ArticulationCfg = ANYMAL_D_CFG.replace(
+        prim_path="{ENV_REGEX_NS}/Robot",
+        init_state=ArticulationCfg.InitialStateCfg(pos=(0.0, 0.0, 1.0)),
+        actuators={"legs": ANYDRIVE_PACE_ACTUATOR_CFG},
+    )
+
+
+@configclass
+class AnymalDPaceEnvCfg(PaceSim2realEnvCfg):
+
+    scene: ANYmalDPaceSceneCfg = ANYmalDPaceSceneCfg()
+    sim2real: PaceCfg = AnymalDPaceCfg()
+
+    def __post_init__(self):
+        # post init of parent
+        super().__post_init__()
+
+        # robot sim and control settings
+        self.sim.dt = 0.0025  # 400Hz simulation
+        self.decimation = 1  # 400Hz control

--- a/source/robot_lab/robot_lab/tasks/manager_based/pace/mdp/__init__.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/pace/mdp/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""This sub-module contains the functions that are specific to the environment."""
+
+from isaaclab.envs.mdp import *  # noqa: F401, F403
+
+from .rewards import *  # noqa: F401, F403

--- a/source/robot_lab/robot_lab/tasks/manager_based/pace/mdp/__init__.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/pace/mdp/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024-2026 Ziqi Fan
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #

--- a/source/robot_lab/robot_lab/tasks/manager_based/pace/mdp/rewards.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/pace/mdp/rewards.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import torch
+from typing import TYPE_CHECKING
+
+from isaaclab.assets import Articulation
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils.math import wrap_to_pi
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedRLEnv
+
+
+def joint_pos_target_l2(env: ManagerBasedRLEnv, target: float, asset_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Penalize joint position deviation from a target value."""
+    # extract the used quantities (to enable type-hinting)
+    asset: Articulation = env.scene[asset_cfg.name]
+    # wrap the joint positions to (-pi, pi)
+    joint_pos = wrap_to_pi(asset.data.joint_pos[:, asset_cfg.joint_ids])
+    # compute the reward
+    return torch.sum(torch.square(joint_pos - target), dim=1)

--- a/source/robot_lab/robot_lab/tasks/manager_based/pace/mdp/rewards.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/pace/mdp/rewards.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024-2026 Ziqi Fan
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #
@@ -5,8 +8,9 @@
 
 from __future__ import annotations
 
-import torch
 from typing import TYPE_CHECKING
+
+import torch
 
 from isaaclab.assets import Articulation
 from isaaclab.managers import SceneEntityCfg

--- a/source/robot_lab/robot_lab/tasks/manager_based/pace/optim/__init__.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/pace/optim/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024-2026 Ziqi Fan
+# SPDX-License-Identifier: Apache-2.0
+
 # © 2025 ETH Zurich, Robotic Systems Lab
 # Author: Filip Bjelonic
 # Licensed under the Apache License 2.0

--- a/source/robot_lab/robot_lab/tasks/manager_based/pace/optim/__init__.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/pace/optim/__init__.py
@@ -1,0 +1,7 @@
+# © 2025 ETH Zurich, Robotic Systems Lab
+# Author: Filip Bjelonic
+# Licensed under the Apache License 2.0
+
+from .cma_es import CMAESOptimizer
+
+__all__ = ["CMAESOptimizer"]

--- a/source/robot_lab/robot_lab/tasks/manager_based/pace/optim/cma_es.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/pace/optim/cma_es.py
@@ -1,0 +1,192 @@
+# © 2025 ETH Zurich, Robotic Systems Lab
+# Author: Filip Bjelonic
+# Licensed under the Apache License 2.0
+
+from __future__ import annotations
+
+import cmaes
+import torch
+from torch.utils.tensorboard import SummaryWriter as TensorboardSummaryWriter
+from datetime import datetime
+import os
+
+
+class CMAESOptimizer:
+    def __init__(self, bounds, population_size, log_dir, joint_order, max_iteration, data, device, epsilon=None, sigma=0.5, save_interval=10, save_optimization_process=False):
+
+        self.joint_order = joint_order
+        self.max_iteration = max_iteration
+        self.epsilon = epsilon
+        self.save_interval = save_interval
+        self.device = device
+        self.save_optimization_process = save_optimization_process
+        self._timer_start = datetime.now()  # timer for logging purposes
+
+        # create log_dir in YY_MM_DD_hh-mm-ss format
+        folder_time = datetime.now().strftime("%y_%m_%d_%H-%M-%S")
+        # create string with time and date
+        log_dir = os.path.join(log_dir, folder_time)
+        os.makedirs(log_dir, exist_ok=True)
+        self.writer = TensorboardSummaryWriter(log_dir=log_dir)
+        torch.save({"bounds": bounds,
+                    "joint_order": joint_order,
+                    "dof_pos": data["dof_pos"],
+                    "des_dof_pos": data["des_dof_pos"],
+                    "time": data["time"]
+                    }, log_dir + "/config.pt")
+
+        self.bounds = bounds
+
+        bounds_normalized = torch.ones_like(bounds)
+        bounds_normalized[:, 0] *= -1
+        mean_normalized = torch.zeros_like(bounds[:, 0])
+
+        self.optimizer = cmaes.CMA(mean=mean_normalized.cpu().numpy(), sigma=sigma, bounds=bounds_normalized.cpu().numpy(), seed=0, population_size=population_size)
+
+        self.scores_counter = 0
+        self.iteration_counter = 0
+
+        self.scores = torch.zeros(population_size, device=device)
+        self.scores_buffer = torch.zeros((max_iteration, population_size), device=device)
+        self.sim_dof_pos_buffer = torch.zeros((population_size, data["dof_pos"].shape[0], len(joint_order)), device=device)
+
+        self.params = torch.zeros((population_size, bounds.shape[0]), device=device)
+        self.sim_params = torch.zeros_like(self.params)
+        if save_optimization_process:
+            self.sim_params_buffer = torch.zeros((max_iteration, population_size, bounds.shape[0]), device=device)
+
+        num_joints = len(joint_order)
+        self.armature_idx = slice(0, num_joints)
+        self.damping_idx = slice(num_joints, 2 * num_joints)
+        self.friction_idx = slice(2 * num_joints, 3 * num_joints)
+        self.bias_idx = slice(3 * num_joints, 4 * num_joints)
+        self.delay_idx = 4 * num_joints
+
+        self._reset_population()
+        print("CMA-ES optimizer initialized.")
+        print("Current iteration: ", self.iteration_counter)
+
+    def ask(self):
+        return self.optimizer.ask()
+
+    def tell(self, sim_dof_pos, real_dof_pos):
+        self.scores += torch.sum(torch.square(sim_dof_pos - real_dof_pos - self.sim_params[:, self.bias_idx]), dim=1)
+        self.sim_dof_pos_buffer[:, self.scores_counter, :] = sim_dof_pos
+        self.scores_counter += 1
+
+    def evolve(self):
+        self.scores /= self.scores_counter
+        self.scores_buffer[self.iteration_counter, :] = self.scores
+        if self.save_optimization_process:
+            self.sim_params_buffer[self.iteration_counter, :, :] = self.sim_params
+        solutions = []
+        for i in range(self.optimizer.population_size):
+            solutions.append((self.params[i].cpu().numpy(), self.scores[i].item()))
+        self.optimizer.tell(solutions)
+        if self.save_interval > 0 and self.iteration_counter % self.save_interval == 0:
+            self.save_checkpoint(self._params_to_sim_params(torch.tensor(self.optimizer._mean, device=self.device)), self.iteration_counter)
+        self._print_iteration()
+
+        self._reset_population()
+
+        self.scores = torch.zeros_like(self.scores)
+        self.scores_counter = 0
+        self.iteration_counter += 1
+        print("CMA-ES optimizer iteration: ", self.iteration_counter)
+
+    def finished(self):
+        finished = self.max_iteration <= self.iteration_counter
+        diff_score = (self.scores_buffer[self.iteration_counter - 1, :].max() - self.scores_buffer[self.iteration_counter - 1, :].min()) / self.scores_buffer[self.iteration_counter - 1, :].min()
+        finished = finished or (self.epsilon is not None and diff_score < self.epsilon)
+        if finished:
+            print("CMA-ES optimization finished.")
+            self.save_checkpoint(self._params_to_sim_params(torch.tensor(self.optimizer._mean, device=self.device)), self.iteration_counter - 1, finished=True)
+        return finished
+
+    def _reset_population(self):
+        for i in range(self.optimizer.population_size):
+            self.params[i, :] = torch.tensor(self.optimizer.ask(), device=self.device)
+        self.sim_params = self._params_to_sim_params(self.params)
+
+    def update_simulator(self, articulation, joint_ids, initial_position):
+        env_ids = torch.arange(len(self.sim_params[:, self.armature_idx]))
+        articulation.write_joint_armature_to_sim(self.sim_params[:, self.armature_idx], joint_ids=joint_ids, env_ids=env_ids)
+        articulation.data.default_joint_armature[:, joint_ids] = self.sim_params[:, self.armature_idx]
+        articulation.write_joint_viscous_friction_coefficient_to_sim(self.sim_params[:, self.damping_idx], joint_ids=joint_ids, env_ids=env_ids)
+        articulation.data.default_joint_viscous_friction_coeff[:, joint_ids] = self.sim_params[:, self.damping_idx]
+        # If we set static friction lower than dynamic friction, the sim complains. So we need to do this weird order.
+        articulation.write_joint_dynamic_friction_coefficient_to_sim(0.0, joint_ids=joint_ids, env_ids=env_ids)
+        articulation.write_joint_friction_coefficient_to_sim(self.sim_params[:, self.friction_idx], joint_ids=joint_ids, env_ids=env_ids)
+        articulation.data.default_joint_friction_coeff[:, joint_ids] = self.sim_params[:, self.friction_idx]
+        articulation.write_joint_dynamic_friction_coefficient_to_sim(self.sim_params[:, self.friction_idx], joint_ids=joint_ids, env_ids=env_ids)
+        articulation.data.default_joint_dynamic_friction_coeff[:, joint_ids] = self.sim_params[:, self.friction_idx]
+        articulation.write_joint_position_to_sim(initial_position + self.sim_params[:, self.bias_idx], joint_ids=joint_ids)
+        articulation.write_joint_velocity_to_sim(torch.zeros_like(initial_position), joint_ids=joint_ids)
+        for drive_type in articulation.actuators.keys():
+            drive_indices = articulation.actuators[drive_type].joint_indices
+            if isinstance(drive_indices, slice):
+                all_idx = torch.arange(joint_ids.shape[0], device=joint_ids.device)
+                drive_indices = all_idx[drive_indices]
+            comparison_matrix = (joint_ids.unsqueeze(1) == drive_indices.unsqueeze(0))
+            drive_joint_idx = torch.argmax(comparison_matrix.int(), dim=0)
+            articulation.actuators[drive_type].update_encoder_bias(self.sim_params[:, self.bias_idx][:, drive_joint_idx])
+            articulation.actuators[drive_type].update_time_lags(self.sim_params[:, self.delay_idx].to(torch.int))
+            articulation.actuators[drive_type].reset(env_ids)
+
+    def _print_iteration(self):
+        min_score = torch.min(self.scores)
+        max_score = torch.max(self.scores)
+        min_index = torch.argmin(self.scores)
+        print("Max score: ", max_score.item())
+        print("Min score: ", min_score.item(), " at index: ", min_index.item())
+        print("Armature: ", self.sim_params[min_index, self.armature_idx].tolist())
+        print("Viscous Friction: ", self.sim_params[min_index, self.damping_idx].tolist())
+        print("Static/Dynamic Friction: ", self.sim_params[min_index, self.friction_idx].tolist())
+        print("Bias: ", self.sim_params[min_index, self.bias_idx].tolist())
+        print("Delay: ", self.sim_params[min_index, self.delay_idx].tolist())
+        print(f"Elapsed time: {(datetime.now() - self._timer_start).total_seconds():.1f} seconds")
+        self._timer_start = datetime.now()
+        self._log()
+
+    def _params_to_sim_params(self, params):
+        sim_params = (params + 1.0) / 2.0  # change range from 0 to 1
+        sim_params = self.bounds[:, 0] + sim_params * (self.bounds[:, 1] - self.bounds[:, 0])  # range from lower to upper bound
+        return sim_params
+
+    def get_best_sim_params(self):
+        best_params = torch.tensor(self.optimizer._mean)
+        return self._params_to_sim_params(best_params)
+
+    def _log(self):
+        min_score, min_score_index = torch.min(self.scores, dim=0)
+        max_score, _ = torch.max(self.scores, dim=0)
+        for i in range(len(self.joint_order)):
+            self.writer.add_histogram("4_Bias/distribution_" + self.joint_order[i], self.sim_params[:, self.bias_idx][:, i], self.iteration_counter)
+            self.writer.add_histogram("3_Static_Dynamic_Friction/distribution_" + self.joint_order[i], self.sim_params[:, self.friction_idx][:, i], self.iteration_counter)
+            self.writer.add_histogram("2_Viscous_Friction/distribution_" + self.joint_order[i], self.sim_params[:, self.damping_idx][:, i], self.iteration_counter)
+            self.writer.add_histogram("1_Armature/distribution_" + self.joint_order[i], self.sim_params[:, self.armature_idx][:, i], self.iteration_counter)
+
+            self.writer.add_scalar("4_Bias/best_" + self.joint_order[i], self.sim_params[min_score_index, self.bias_idx][i].item(), self.iteration_counter)
+            self.writer.add_scalar("3_Static_Dynamic_Friction/best_" + self.joint_order[i], self.sim_params[min_score_index, self.friction_idx][i].item(), self.iteration_counter)
+            self.writer.add_scalar("2_Viscous_Friction/best_" + self.joint_order[i], self.sim_params[min_score_index, self.damping_idx][i].item(), self.iteration_counter)
+            self.writer.add_scalar("1_Armature/best_" + self.joint_order[i], self.sim_params[min_score_index, self.armature_idx][i].item(), self.iteration_counter)
+        self.writer.add_histogram("0_Delay/distribution", self.sim_params[:, self.delay_idx], self.iteration_counter)
+        self.writer.add_scalar("0_Delay/best", self.sim_params[min_score_index, self.delay_idx].item(), self.iteration_counter)
+
+        self.writer.add_scalar("0_Episode/score", min_score.item(), self.iteration_counter)
+        self.writer.add_scalar("0_Episode/max_score", max_score.item(), self.iteration_counter)
+        self.writer.add_scalar("0_Episode/diff_score", (max_score - min_score) / min_score, self.iteration_counter)
+
+    def save_checkpoint(self, mean, iteration, finished=False):
+        min_index = torch.argmin(self.scores_buffer[iteration, :])
+        best_traj = self.sim_dof_pos_buffer[min_index].detach().clone()
+        best_traj = best_traj.cpu()
+        torch.save(best_traj, os.path.join(self.writer.log_dir, "best_trajectory.pt"))
+        torch.save(mean, os.path.join(self.writer.log_dir, "mean_" + f"{iteration:03}" + ".pt"))
+        if finished and self.save_optimization_process:
+            torch.save({"params_buffer": self.sim_params_buffer,
+                        "scores_buffer": self.scores_buffer, },
+                       os.path.join(self.writer.log_dir, "progress.pt"))
+
+    def close(self):
+        self.writer.close()

--- a/source/robot_lab/robot_lab/tasks/manager_based/pace/optim/cma_es.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/pace/optim/cma_es.py
@@ -1,19 +1,35 @@
+# Copyright (c) 2024-2026 Ziqi Fan
+# SPDX-License-Identifier: Apache-2.0
+
 # © 2025 ETH Zurich, Robotic Systems Lab
 # Author: Filip Bjelonic
 # Licensed under the Apache License 2.0
 
 from __future__ import annotations
 
+import os
+from datetime import datetime
+
 import cmaes
 import torch
 from torch.utils.tensorboard import SummaryWriter as TensorboardSummaryWriter
-from datetime import datetime
-import os
 
 
 class CMAESOptimizer:
-    def __init__(self, bounds, population_size, log_dir, joint_order, max_iteration, data, device, epsilon=None, sigma=0.5, save_interval=10, save_optimization_process=False):
-
+    def __init__(
+        self,
+        bounds,
+        population_size,
+        log_dir,
+        joint_order,
+        max_iteration,
+        data,
+        device,
+        epsilon=None,
+        sigma=0.5,
+        save_interval=10,
+        save_optimization_process=False,
+    ):
         self.joint_order = joint_order
         self.max_iteration = max_iteration
         self.epsilon = epsilon
@@ -28,12 +44,16 @@ class CMAESOptimizer:
         log_dir = os.path.join(log_dir, folder_time)
         os.makedirs(log_dir, exist_ok=True)
         self.writer = TensorboardSummaryWriter(log_dir=log_dir)
-        torch.save({"bounds": bounds,
-                    "joint_order": joint_order,
-                    "dof_pos": data["dof_pos"],
-                    "des_dof_pos": data["des_dof_pos"],
-                    "time": data["time"]
-                    }, log_dir + "/config.pt")
+        torch.save(
+            {
+                "bounds": bounds,
+                "joint_order": joint_order,
+                "dof_pos": data["dof_pos"],
+                "des_dof_pos": data["des_dof_pos"],
+                "time": data["time"],
+            },
+            log_dir + "/config.pt",
+        )
 
         self.bounds = bounds
 
@@ -41,14 +61,22 @@ class CMAESOptimizer:
         bounds_normalized[:, 0] *= -1
         mean_normalized = torch.zeros_like(bounds[:, 0])
 
-        self.optimizer = cmaes.CMA(mean=mean_normalized.cpu().numpy(), sigma=sigma, bounds=bounds_normalized.cpu().numpy(), seed=0, population_size=population_size)
+        self.optimizer = cmaes.CMA(
+            mean=mean_normalized.cpu().numpy(),
+            sigma=sigma,
+            bounds=bounds_normalized.cpu().numpy(),
+            seed=0,
+            population_size=population_size,
+        )
 
         self.scores_counter = 0
         self.iteration_counter = 0
 
         self.scores = torch.zeros(population_size, device=device)
         self.scores_buffer = torch.zeros((max_iteration, population_size), device=device)
-        self.sim_dof_pos_buffer = torch.zeros((population_size, data["dof_pos"].shape[0], len(joint_order)), device=device)
+        self.sim_dof_pos_buffer = torch.zeros(
+            (population_size, data["dof_pos"].shape[0], len(joint_order)), device=device
+        )
 
         self.params = torch.zeros((population_size, bounds.shape[0]), device=device)
         self.sim_params = torch.zeros_like(self.params)
@@ -84,7 +112,10 @@ class CMAESOptimizer:
             solutions.append((self.params[i].cpu().numpy(), self.scores[i].item()))
         self.optimizer.tell(solutions)
         if self.save_interval > 0 and self.iteration_counter % self.save_interval == 0:
-            self.save_checkpoint(self._params_to_sim_params(torch.tensor(self.optimizer._mean, device=self.device)), self.iteration_counter)
+            self.save_checkpoint(
+                self._params_to_sim_params(torch.tensor(self.optimizer._mean, device=self.device)),
+                self.iteration_counter,
+            )
         self._print_iteration()
 
         self._reset_population()
@@ -96,11 +127,18 @@ class CMAESOptimizer:
 
     def finished(self):
         finished = self.max_iteration <= self.iteration_counter
-        diff_score = (self.scores_buffer[self.iteration_counter - 1, :].max() - self.scores_buffer[self.iteration_counter - 1, :].min()) / self.scores_buffer[self.iteration_counter - 1, :].min()
+        diff_score = (
+            self.scores_buffer[self.iteration_counter - 1, :].max()
+            - self.scores_buffer[self.iteration_counter - 1, :].min()
+        ) / self.scores_buffer[self.iteration_counter - 1, :].min()
         finished = finished or (self.epsilon is not None and diff_score < self.epsilon)
         if finished:
             print("CMA-ES optimization finished.")
-            self.save_checkpoint(self._params_to_sim_params(torch.tensor(self.optimizer._mean, device=self.device)), self.iteration_counter - 1, finished=True)
+            self.save_checkpoint(
+                self._params_to_sim_params(torch.tensor(self.optimizer._mean, device=self.device)),
+                self.iteration_counter - 1,
+                finished=True,
+            )
         return finished
 
     def _reset_population(self):
@@ -110,26 +148,38 @@ class CMAESOptimizer:
 
     def update_simulator(self, articulation, joint_ids, initial_position):
         env_ids = torch.arange(len(self.sim_params[:, self.armature_idx]))
-        articulation.write_joint_armature_to_sim(self.sim_params[:, self.armature_idx], joint_ids=joint_ids, env_ids=env_ids)
+        articulation.write_joint_armature_to_sim(
+            self.sim_params[:, self.armature_idx], joint_ids=joint_ids, env_ids=env_ids
+        )
         articulation.data.default_joint_armature[:, joint_ids] = self.sim_params[:, self.armature_idx]
-        articulation.write_joint_viscous_friction_coefficient_to_sim(self.sim_params[:, self.damping_idx], joint_ids=joint_ids, env_ids=env_ids)
+        articulation.write_joint_viscous_friction_coefficient_to_sim(
+            self.sim_params[:, self.damping_idx], joint_ids=joint_ids, env_ids=env_ids
+        )
         articulation.data.default_joint_viscous_friction_coeff[:, joint_ids] = self.sim_params[:, self.damping_idx]
         # If we set static friction lower than dynamic friction, the sim complains. So we need to do this weird order.
         articulation.write_joint_dynamic_friction_coefficient_to_sim(0.0, joint_ids=joint_ids, env_ids=env_ids)
-        articulation.write_joint_friction_coefficient_to_sim(self.sim_params[:, self.friction_idx], joint_ids=joint_ids, env_ids=env_ids)
+        articulation.write_joint_friction_coefficient_to_sim(
+            self.sim_params[:, self.friction_idx], joint_ids=joint_ids, env_ids=env_ids
+        )
         articulation.data.default_joint_friction_coeff[:, joint_ids] = self.sim_params[:, self.friction_idx]
-        articulation.write_joint_dynamic_friction_coefficient_to_sim(self.sim_params[:, self.friction_idx], joint_ids=joint_ids, env_ids=env_ids)
+        articulation.write_joint_dynamic_friction_coefficient_to_sim(
+            self.sim_params[:, self.friction_idx], joint_ids=joint_ids, env_ids=env_ids
+        )
         articulation.data.default_joint_dynamic_friction_coeff[:, joint_ids] = self.sim_params[:, self.friction_idx]
-        articulation.write_joint_position_to_sim(initial_position + self.sim_params[:, self.bias_idx], joint_ids=joint_ids)
+        articulation.write_joint_position_to_sim(
+            initial_position + self.sim_params[:, self.bias_idx], joint_ids=joint_ids
+        )
         articulation.write_joint_velocity_to_sim(torch.zeros_like(initial_position), joint_ids=joint_ids)
         for drive_type in articulation.actuators.keys():
             drive_indices = articulation.actuators[drive_type].joint_indices
             if isinstance(drive_indices, slice):
                 all_idx = torch.arange(joint_ids.shape[0], device=joint_ids.device)
                 drive_indices = all_idx[drive_indices]
-            comparison_matrix = (joint_ids.unsqueeze(1) == drive_indices.unsqueeze(0))
+            comparison_matrix = joint_ids.unsqueeze(1) == drive_indices.unsqueeze(0)
             drive_joint_idx = torch.argmax(comparison_matrix.int(), dim=0)
-            articulation.actuators[drive_type].update_encoder_bias(self.sim_params[:, self.bias_idx][:, drive_joint_idx])
+            articulation.actuators[drive_type].update_encoder_bias(
+                self.sim_params[:, self.bias_idx][:, drive_joint_idx]
+            )
             articulation.actuators[drive_type].update_time_lags(self.sim_params[:, self.delay_idx].to(torch.int))
             articulation.actuators[drive_type].reset(env_ids)
 
@@ -150,7 +200,9 @@ class CMAESOptimizer:
 
     def _params_to_sim_params(self, params):
         sim_params = (params + 1.0) / 2.0  # change range from 0 to 1
-        sim_params = self.bounds[:, 0] + sim_params * (self.bounds[:, 1] - self.bounds[:, 0])  # range from lower to upper bound
+        sim_params = self.bounds[:, 0] + sim_params * (
+            self.bounds[:, 1] - self.bounds[:, 0]
+        )  # range from lower to upper bound
         return sim_params
 
     def get_best_sim_params(self):
@@ -161,17 +213,51 @@ class CMAESOptimizer:
         min_score, min_score_index = torch.min(self.scores, dim=0)
         max_score, _ = torch.max(self.scores, dim=0)
         for i in range(len(self.joint_order)):
-            self.writer.add_histogram("4_Bias/distribution_" + self.joint_order[i], self.sim_params[:, self.bias_idx][:, i], self.iteration_counter)
-            self.writer.add_histogram("3_Static_Dynamic_Friction/distribution_" + self.joint_order[i], self.sim_params[:, self.friction_idx][:, i], self.iteration_counter)
-            self.writer.add_histogram("2_Viscous_Friction/distribution_" + self.joint_order[i], self.sim_params[:, self.damping_idx][:, i], self.iteration_counter)
-            self.writer.add_histogram("1_Armature/distribution_" + self.joint_order[i], self.sim_params[:, self.armature_idx][:, i], self.iteration_counter)
+            self.writer.add_histogram(
+                "4_Bias/distribution_" + self.joint_order[i],
+                self.sim_params[:, self.bias_idx][:, i],
+                self.iteration_counter,
+            )
+            self.writer.add_histogram(
+                "3_Static_Dynamic_Friction/distribution_" + self.joint_order[i],
+                self.sim_params[:, self.friction_idx][:, i],
+                self.iteration_counter,
+            )
+            self.writer.add_histogram(
+                "2_Viscous_Friction/distribution_" + self.joint_order[i],
+                self.sim_params[:, self.damping_idx][:, i],
+                self.iteration_counter,
+            )
+            self.writer.add_histogram(
+                "1_Armature/distribution_" + self.joint_order[i],
+                self.sim_params[:, self.armature_idx][:, i],
+                self.iteration_counter,
+            )
 
-            self.writer.add_scalar("4_Bias/best_" + self.joint_order[i], self.sim_params[min_score_index, self.bias_idx][i].item(), self.iteration_counter)
-            self.writer.add_scalar("3_Static_Dynamic_Friction/best_" + self.joint_order[i], self.sim_params[min_score_index, self.friction_idx][i].item(), self.iteration_counter)
-            self.writer.add_scalar("2_Viscous_Friction/best_" + self.joint_order[i], self.sim_params[min_score_index, self.damping_idx][i].item(), self.iteration_counter)
-            self.writer.add_scalar("1_Armature/best_" + self.joint_order[i], self.sim_params[min_score_index, self.armature_idx][i].item(), self.iteration_counter)
+            self.writer.add_scalar(
+                "4_Bias/best_" + self.joint_order[i],
+                self.sim_params[min_score_index, self.bias_idx][i].item(),
+                self.iteration_counter,
+            )
+            self.writer.add_scalar(
+                "3_Static_Dynamic_Friction/best_" + self.joint_order[i],
+                self.sim_params[min_score_index, self.friction_idx][i].item(),
+                self.iteration_counter,
+            )
+            self.writer.add_scalar(
+                "2_Viscous_Friction/best_" + self.joint_order[i],
+                self.sim_params[min_score_index, self.damping_idx][i].item(),
+                self.iteration_counter,
+            )
+            self.writer.add_scalar(
+                "1_Armature/best_" + self.joint_order[i],
+                self.sim_params[min_score_index, self.armature_idx][i].item(),
+                self.iteration_counter,
+            )
         self.writer.add_histogram("0_Delay/distribution", self.sim_params[:, self.delay_idx], self.iteration_counter)
-        self.writer.add_scalar("0_Delay/best", self.sim_params[min_score_index, self.delay_idx].item(), self.iteration_counter)
+        self.writer.add_scalar(
+            "0_Delay/best", self.sim_params[min_score_index, self.delay_idx].item(), self.iteration_counter
+        )
 
         self.writer.add_scalar("0_Episode/score", min_score.item(), self.iteration_counter)
         self.writer.add_scalar("0_Episode/max_score", max_score.item(), self.iteration_counter)
@@ -184,9 +270,13 @@ class CMAESOptimizer:
         torch.save(best_traj, os.path.join(self.writer.log_dir, "best_trajectory.pt"))
         torch.save(mean, os.path.join(self.writer.log_dir, "mean_" + f"{iteration:03}" + ".pt"))
         if finished and self.save_optimization_process:
-            torch.save({"params_buffer": self.sim_params_buffer,
-                        "scores_buffer": self.scores_buffer, },
-                       os.path.join(self.writer.log_dir, "progress.pt"))
+            torch.save(
+                {
+                    "params_buffer": self.sim_params_buffer,
+                    "scores_buffer": self.scores_buffer,
+                },
+                os.path.join(self.writer.log_dir, "progress.pt"),
+            )
 
     def close(self):
         self.writer.close()

--- a/source/robot_lab/robot_lab/tasks/manager_based/pace/pace_sim2real_env_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/pace/pace_sim2real_env_cfg.py
@@ -1,0 +1,148 @@
+# © 2025 ETH Zurich, Robotic Systems Lab
+# Author: Filip Bjelonic
+# Licensed under the Apache License 2.0
+
+# import math
+from dataclasses import MISSING
+import torch
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import ArticulationCfg, AssetBaseCfg
+from isaaclab.envs import ManagerBasedRLEnvCfg
+# from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+# from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.scene import InteractiveSceneCfg
+from isaaclab.utils import configclass
+from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
+
+from . import mdp
+
+
+##
+# Scene definition
+##
+
+
+@configclass
+class PaceSim2realSceneCfg(InteractiveSceneCfg):
+
+    # ground plane
+    ground = AssetBaseCfg(
+        prim_path="/World/ground",
+        spawn=sim_utils.GroundPlaneCfg(size=(100.0, 100.0)),
+    )
+    env_spacing: float = 2.5
+    num_envs: int = 4096
+
+    # robots
+    robot: ArticulationCfg = MISSING
+
+    # lights
+    sky_light = AssetBaseCfg(
+        prim_path="/World/skyLight",
+        spawn=sim_utils.DomeLightCfg(
+            intensity=750.0,
+            texture_file=f"{ISAAC_NUCLEUS_DIR}/Materials/Textures/Skies/PolyHaven/kloofendal_43d_clear_puresky_4k.hdr",
+        ),
+    )
+
+
+##
+# MDP settings
+##
+
+
+@configclass
+class ActionsCfg:
+    """Action specifications for the MDP."""
+    joint_pos = mdp.JointPositionActionCfg(asset_name="robot", joint_names=[".*"], scale=1.0, use_default_offset=False)  # actions = absolute joint position targets
+
+
+@configclass
+class ObservationsCfg:
+    """Observation specifications for the MDP."""
+
+    @configclass
+    class PolicyCfg(ObsGroup):
+        """Observations for policy group."""
+        joint_pos = ObsTerm(func=mdp.joint_pos_rel)
+        joint_vel = ObsTerm(func=mdp.joint_vel_rel)
+        actions = ObsTerm(func=mdp.last_action)
+
+        def __post_init__(self):
+            self.enable_corruption = False
+            self.concatenate_terms = False
+
+    # observation groups
+    policy: PolicyCfg = PolicyCfg()
+
+
+@configclass
+class RewardsCfg:
+    """Reward terms for the MDP."""
+    dof_pos_limits = RewTerm(func=mdp.joint_pos_limits, weight=0.0)
+
+
+@configclass
+class TerminationsCfg:
+    """Termination terms for the MDP."""
+    time_out = DoneTerm(func=mdp.time_out, time_out=False)
+
+
+@configclass
+class CMAESOptimizerCfg:
+    """CMA-ES optimizer configuration."""
+    max_iteration: int = 200
+    epsilon: float = 1e-2
+    sigma: float = 0.5
+    save_interval: int = 10
+    save_optimization_process: bool = False  # consume more disk space if True, saves optimization process after finishing
+
+
+@configclass
+class PaceCfg:
+    """Overall configuration for Pace Sim2Real task."""
+    cmaes: CMAESOptimizerCfg = CMAESOptimizerCfg()
+
+    robot_name: str = MISSING
+    data_dir: str = MISSING
+    joint_order: list = MISSING
+    bounds_params: torch.Tensor = MISSING
+
+##
+# Environment configuration
+##
+
+
+@configclass
+class PaceSim2realEnvCfg(ManagerBasedRLEnvCfg):
+    # Scene settings
+    scene: PaceSim2realSceneCfg = PaceSim2realSceneCfg()
+    # Basic settings
+    actions: ActionsCfg = ActionsCfg()  # action = joint position targets (scale = 1.0 -> impedance control)
+
+    observations: ObservationsCfg = ObservationsCfg()
+    rewards: RewardsCfg = RewardsCfg()
+    terminations: TerminationsCfg = TerminationsCfg()
+
+    sim2real: PaceCfg = PaceCfg()
+
+    # Post initialization
+    def __post_init__(self) -> None:
+        """Post initialization."""
+        # general settings
+        self.decimation = 1
+        self.episode_length_s = 99999.0  # long episodes
+        # viewer settings
+        self.viewer.lookat = (0.0, 0.0, 0.8)
+        self.viewer.eye = (2.0, 2.0, 1.5)
+        # simulation settings
+        self.sim.dt = 0.0025  # 400Hz simulation
+        self.sim.render_interval = 4  # render at 100Hz
+
+        self.scene.robot.spawn.articulation_props.fix_root_link = True
+

--- a/source/robot_lab/robot_lab/tasks/manager_based/pace/pace_sim2real_env_cfg.py
+++ b/source/robot_lab/robot_lab/tasks/manager_based/pace/pace_sim2real_env_cfg.py
@@ -1,18 +1,24 @@
+# Copyright (c) 2024-2026 Ziqi Fan
+# SPDX-License-Identifier: Apache-2.0
+
 # © 2025 ETH Zurich, Robotic Systems Lab
 # Author: Filip Bjelonic
 # Licensed under the Apache License 2.0
 
 # import math
 from dataclasses import MISSING
+
 import torch
 
 import isaaclab.sim as sim_utils
 from isaaclab.assets import ArticulationCfg, AssetBaseCfg
 from isaaclab.envs import ManagerBasedRLEnvCfg
+
 # from isaaclab.managers import EventTermCfg as EventTerm
 from isaaclab.managers import ObservationGroupCfg as ObsGroup
 from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import RewardTermCfg as RewTerm
+
 # from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers import TerminationTermCfg as DoneTerm
 from isaaclab.scene import InteractiveSceneCfg
@@ -21,7 +27,6 @@ from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 
 from . import mdp
 
-
 ##
 # Scene definition
 ##
@@ -29,7 +34,6 @@ from . import mdp
 
 @configclass
 class PaceSim2realSceneCfg(InteractiveSceneCfg):
-
     # ground plane
     ground = AssetBaseCfg(
         prim_path="/World/ground",
@@ -59,7 +63,10 @@ class PaceSim2realSceneCfg(InteractiveSceneCfg):
 @configclass
 class ActionsCfg:
     """Action specifications for the MDP."""
-    joint_pos = mdp.JointPositionActionCfg(asset_name="robot", joint_names=[".*"], scale=1.0, use_default_offset=False)  # actions = absolute joint position targets
+
+    joint_pos = mdp.JointPositionActionCfg(
+        asset_name="robot", joint_names=[".*"], scale=1.0, use_default_offset=False
+    )  # actions = absolute joint position targets
 
 
 @configclass
@@ -69,6 +76,7 @@ class ObservationsCfg:
     @configclass
     class PolicyCfg(ObsGroup):
         """Observations for policy group."""
+
         joint_pos = ObsTerm(func=mdp.joint_pos_rel)
         joint_vel = ObsTerm(func=mdp.joint_vel_rel)
         actions = ObsTerm(func=mdp.last_action)
@@ -84,34 +92,41 @@ class ObservationsCfg:
 @configclass
 class RewardsCfg:
     """Reward terms for the MDP."""
+
     dof_pos_limits = RewTerm(func=mdp.joint_pos_limits, weight=0.0)
 
 
 @configclass
 class TerminationsCfg:
     """Termination terms for the MDP."""
+
     time_out = DoneTerm(func=mdp.time_out, time_out=False)
 
 
 @configclass
 class CMAESOptimizerCfg:
     """CMA-ES optimizer configuration."""
+
     max_iteration: int = 200
     epsilon: float = 1e-2
     sigma: float = 0.5
     save_interval: int = 10
-    save_optimization_process: bool = False  # consume more disk space if True, saves optimization process after finishing
+    save_optimization_process: bool = (
+        False  # consume more disk space if True, saves optimization process after finishing
+    )
 
 
 @configclass
 class PaceCfg:
     """Overall configuration for Pace Sim2Real task."""
+
     cmaes: CMAESOptimizerCfg = CMAESOptimizerCfg()
 
     robot_name: str = MISSING
     data_dir: str = MISSING
     joint_order: list = MISSING
     bounds_params: torch.Tensor = MISSING
+
 
 ##
 # Environment configuration
@@ -145,4 +160,3 @@ class PaceSim2realEnvCfg(ManagerBasedRLEnvCfg):
         self.sim.render_interval = 4  # render at 100Hz
 
         self.scene.robot.spawn.articulation_props.fix_root_link = True
-

--- a/source/robot_lab/robot_lab/utils/__init__.py
+++ b/source/robot_lab/robot_lab/utils/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2024-2026 Ziqi Fan
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared utilities for robot_lab."""

--- a/source/robot_lab/robot_lab/utils/paths.py
+++ b/source/robot_lab/robot_lab/utils/paths.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2024-2026 Ziqi Fan
+# SPDX-License-Identifier: Apache-2.0
+
 # © 2025 ETH Zurich, Robotic Systems Lab
 # Author: Filip Bjelonic
 # Licensed under the Apache License 2.0

--- a/source/robot_lab/robot_lab/utils/paths.py
+++ b/source/robot_lab/robot_lab/utils/paths.py
@@ -1,0 +1,30 @@
+# © 2025 ETH Zurich, Robotic Systems Lab
+# Author: Filip Bjelonic
+# Licensed under the Apache License 2.0
+
+import os
+from pathlib import Path
+
+# optional environment-variable override
+PACE_ROOT_ENV = "PACE_ROOT"
+
+
+def project_root() -> Path:
+    """
+    Returns the top-level project directory.
+
+    Priority:
+      1) $PACE_ROOT if set
+      2) walk up from this file until we find a marker (.project-root / .git)
+      3) fallback: 3 levels above this file
+    """
+    if PACE_ROOT_ENV in os.environ:
+        return Path(os.environ[PACE_ROOT_ENV]).expanduser().resolve()
+
+    here = Path(__file__).resolve()
+    for parent in [here] + list(here.parents):
+        if (parent / ".project-root").exists() or (parent / ".git").exists():
+            return parent
+
+    # fallback: 3 levels up from utils/
+    return here.parents[3]

--- a/source/robot_lab/setup.py
+++ b/source/robot_lab/setup.py
@@ -25,6 +25,8 @@ INSTALL_REQUIRES = [
     "pinocchio",
     # rl
     "cusrl[all]",
+    # pace (system identification)
+    "cmaes",
 ]
 
 # Installation operation


### PR DESCRIPTION
## Summary

Integrate the upstream [`leggedrobotics/pace-sim2real`](https://github.com/leggedrobotics/pace-sim2real) into `robot_lab` as first-class modules, and register a demo task `Isaac-Pace-Anymal-D-v0` that mirrors the PACE ANYmal-D example.

PACE (Precise Adaptation through Continuous Evolution) estimates physical actuator and joint parameters (armature, viscous friction, static/dynamic friction, encoder bias, command delay) from chirp-excitation data using CMA-ES, then lets you apply those parameters back into your simulation for higher-fidelity sim-to-real transfer. See the [PACE documentation](https://pace.filipbjelonic.com) and [paper](https://arxiv.org/pdf/2509.06342).

## What's added

- `robot_lab.actuators.PaceDCMotor` / `PaceDCMotorCfg` — DCMotor with encoder bias and torque delay buffer (port of upstream).
- `robot_lab.utils.paths.project_root()` — repo-root helper used by the PACE scripts that go through the IsaacLab launcher.
- `robot_lab.tasks.manager_based.pace/` — base env_cfg, `mdp/`, `optim/CMAESOptimizer`, `agents/` placeholder.
- `robot_lab.tasks.manager_based.pace.config.anymal_d/` — `AnymalDPaceEnvCfg` and registration of `Isaac-Pace-Anymal-D-v0`.
- `scripts/pace/{data_collection,fit,plot_trajectory}.py` — three user-facing entry points mirroring upstream. `plot_trajectory.py` resolves the project root from `__file__` so it can run offline without launching Isaac Sim.
- `setup.py`: add `cmaes` runtime dependency.
- `.gitignore`: ignore root-level `/data/` for chirp recordings.
- README: PACE workflow section under "Try examples" + acknowledgement.

## Usage

```bash
python scripts/pace/data_collection.py --headless --task=Isaac-Pace-Anymal-D-v0
python scripts/pace/fit.py --headless --task=Isaac-Pace-Anymal-D-v0 --num_envs=4096
python scripts/pace/plot_trajectory.py --plot_trajectory --plot_score --robot_name=anymal_d_sim
```

Outputs: `data/anymal_d_sim/chirp_data.pt`, `logs/pace/anymal_d_sim/<timestamp>/{config.pt, mean_xxx.pt, best_trajectory.pt}`.

## Notes

- PACE is developed against Isaac Sim 5.0+. On 4.5 the joint viscous friction setter is silently ignored, degrading identification quality.
- All upstream PACE invariants preserved (`fix_root_link=True`, `static < dynamic friction` write order, 49-dim parameter layout, ANYmal-D 12-joint order).
- Existing locomotion tasks (e.g. `Isaac-Velocity-Flat-Anymal-D-v0`) are not affected.
- pre-commit (ruff lint + ruff-format + SPDX header insertion + codespell + ...) passes on all PACE files.

## Test Plan (verified locally on RTX 4090, Isaac Sim 5.x)

- [x] `pip install -e source/robot_lab` succeeds and pulls in `cmaes` (`cmaes-0.13.0`)
- [x] `Isaac-Pace-Anymal-D-v0` discovered via `robot_lab.tasks` and `parse_env_cfg` succeeds (verified end-to-end via `data_collection.py` and `fit.py`)
- [x] `python scripts/pace/data_collection.py --headless --task=Isaac-Pace-Anymal-D-v0 --num_envs=1 --duration=1` produces `data/anymal_d_sim/chirp_data.pt` with `{time:[400], dof_pos:[400,12], des_dof_pos:[400,12]}`
- [x] `python scripts/pace/fit.py --headless --task=Isaac-Pace-Anymal-D-v0 --num_envs=256` runs all 200 CMA-ES generations and writes `mean_000.pt … mean_199.pt`, `best_trajectory.pt`, TensorBoard events; score decreases monotonically (e.g. min 0.124 → 0.059 over the first 7 generations)
- [x] `MPLBACKEND=Agg python scripts/pace/plot_trajectory.py --plot_trajectory --robot_name=anymal_d_sim` runs offline (no Isaac Sim launch) and recovers parameters close to ground truth: armature ≈ 0.100 (truth 0.1), viscous friction ≈ 4.45 (truth 4.5), encoder bias ≈ 0.05 (truth 0.05), delay ≈ 5.67 (truth 5)
- [x] `Isaac-Velocity-Flat-Anymal-D-v0` and other existing tasks remain registered (no regression)
- [x] `pre-commit run --all-files` passes